### PR TITLE
Add lz4 compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -337,6 +342,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gcc"
+version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "getopts"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +465,7 @@ dependencies = [
  "heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lz4 1.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -470,6 +486,25 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lz4"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lz4-sys 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "skeptic 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -630,6 +665,15 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -821,6 +865,15 @@ dependencies = [
  "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "skeptic"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pulldown-cmark 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1027,6 +1080,7 @@ dependencies = [
 "checksum bindgen 0.37.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1b25ab82877ea8fe6ce1ce1f8ac54361f0218bad900af9eb11803994bf67c221"
 "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
+"checksum bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4f67931368edf3a9a51d29886d245f1c3db2f1ef0dcc9e35ff70341b78c10d23"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "74c0b906e9446b0a2e4f760cdb3fa4b2c48cdc6db8766a845c54b6ff063fd2e9"
 "checksum cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "49ec142f5768efb5b7622aebc3fdbdbb8950a4b9ba996393cb76ef7466e8747d"
@@ -1056,6 +1110,8 @@ dependencies = [
 "checksum futures-io 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6a0470fdba9dc87c27a3564ad6d5cc04e080f3afa26c93549728cce46ab21a2"
 "checksum futures-sink 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a8a93a7c480876b8e02cdd70022e7eb9c8423575ea6a25a0b749b18834c16412"
 "checksum futures-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0cf12a3fc1ccaf1bc2901ec6e0ed6ed407a4f16eaa20dd838f40cabf5f7b31f1"
+"checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+"checksum getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "b900c08c1939860ce8b54dc6a89e26e00c04c380fd0e09796799bd7f12861e05"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
 "checksum heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "46f96d52fb1564059fc97b85ef6165728cc30198ab60073bf114c66c4c89bb5d"
@@ -1069,6 +1125,8 @@ dependencies = [
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
 "checksum librocksdb-sys 5.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "474d805d72e23a06310fa5201dfe182dc4b80ab1f18bb2823c1ac17ff9dcbaa2"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
+"checksum lz4 1.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fe55d2ebbc2e4fc987e6fbfc13f416d97b06d06e50bc1124d613aa790842f80c"
+"checksum lz4-sys 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a59044c3ba3994f3d2aa2270ddd6c5947922219501e67efde5604d36aad462b5"
 "checksum make-cmd 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8ca8afbe8af1785e09636acb5a41e08a765f5f0340568716c18a8700ba3c0d3"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
@@ -1089,6 +1147,7 @@ dependencies = [
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum proc-macro2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "77997c53ae6edd6d187fec07ec41b207063b5ee6f33680e9fa86d405cdd313d4"
 "checksum proc-macro2 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c65b1ea15bb859d922cade2d1765b4b88beac339cbfad545ef2d2ef8c8215ee6"
+"checksum pulldown-cmark 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1058d7bb927ca067656537eec4e02c2b4b70eaaa129664c5b90c111e20326f41"
 "checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
@@ -1113,6 +1172,7 @@ dependencies = [
 "checksum serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)" = "0c3adf19c07af6d186d91dae8927b83b0553d07ca56cbf7f2f32560455c91920"
 "checksum serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)" = "3525a779832b08693031b8ecfb0de81cd71cfd3812088fafe9a7496789572124"
 "checksum serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ad8bcf487be7d2e15d3d543f04312de991d631cfe1b43ea0ade69e6a8a5b16a1"
+"checksum skeptic 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd7d8dc1315094150052d0ab767840376335a98ac66ef313ff911cdf439a5b69"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2beff8ebc3658f07512a413866875adddd20f4fd47b2a4e6c9da65cd281baaea"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,11 @@ default=[]
 trace=[]
 nerf=[]
 enable_rocksdb=["rocksdb"]
+enable_lz4=["lz4"]
 
 [dependencies]
 rocksdb = { version = "0.10.1", optional = true }
+lz4 = { version = "1.22.0", optional = true }
 futures-core = "0.2.1"
 futures-util = "0.2.1"
 futures-executor = "0.2.1"

--- a/src/disk_store/rocksdb.rs
+++ b/src/disk_store/rocksdb.rs
@@ -3,7 +3,7 @@ extern crate rocksdb;
 use std::sync::Arc;
 
 use bincode::{serialize, deserialize};
-use byteorder::{ByteOrder, LittleEndian};
+use byteorder::{ByteOrder, BigEndian};
 use self::rocksdb::*;
 
 use disk_store::interface::*;
@@ -18,10 +18,16 @@ impl RocksDB {
         let mut options = Options::default();
         options.create_if_missing(true);
         options.create_missing_column_families(true);
-        let db = DB::open_cf(&options, path, &vec!["metadata", "partitions"]).unwrap();
-        RocksDB {
-            db,
-        }
+
+        let mut partitions_options = Options::default();
+        #[cfg(feature = "enable_lz4")]
+            partitions_options.set_compression_type(DBCompressionType::None);
+
+        let db = DB::open_cf_descriptors(&options, path, vec![
+            ColumnFamilyDescriptor::new("metadata", Options::default()),
+            ColumnFamilyDescriptor::new("partitions", partitions_options),
+        ]).unwrap();
+        RocksDB { db }
     }
 
     fn metadata(&self) -> ColumnFamily {
@@ -38,7 +44,7 @@ impl DiskStore for RocksDB {
         let mut metadata = Vec::new();
         let iter = self.db.iterator_cf(self.metadata(), IteratorMode::Start).unwrap();
         for (key, value) in iter {
-            let partition_id = LittleEndian::read_u64(&key) as PartitionID;
+            let partition_id = BigEndian::read_u64(&key) as PartitionID;
             let MetaData { tablename, len, columns } = deserialize(&value).unwrap();
             metadata.push(PartitionMetadata {
                 id: partition_id,
@@ -59,14 +65,13 @@ impl DiskStore for RocksDB {
         let mut tx = WriteBatch::default();
 
         let mut key = [0; 8];
-        LittleEndian::write_u64(&mut key, partition as u64);
+        BigEndian::write_u64(&mut key, partition as u64);
         let md = MetaData {
             tablename: tablename.to_string(),
             len: columns[0].len(),
             columns: columns.iter().map(|c| c.name().to_string()).collect(),
         };
         tx.put_cf(self.metadata(), &key, &serialize(&md).unwrap()).unwrap();
-
         for column in columns {
             let key = column_key(partition, column.name());
             let data = serialize(column.as_ref()).unwrap();
@@ -79,7 +84,7 @@ impl DiskStore for RocksDB {
 
 fn column_key(id: PartitionID, column_name: &str) -> Vec<u8> {
     let mut key = vec![0; 8];
-    LittleEndian::write_u64(&mut key, id as u64);
+    BigEndian::write_u64(&mut key, id as u64);
     key.push('.' as u8);
     key.extend(column_name.as_bytes());
     key

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -14,7 +14,7 @@ pub use self::typed_vec::{
     AnyVec,
     GenericVec,
     GenericIntVec,
-    IntoUsize,
+    CastUsize,
     ConstType,
 };
 

--- a/src/engine/typed_vec.rs
+++ b/src/engine/typed_vec.rs
@@ -270,7 +270,7 @@ impl GenericVec<u64> for u64 {
     fn unwrap<'a, 'b>(vec: &'b AnyVec<'a>) -> &'b [u64] where u64: 'a { vec.cast_ref_u64() }
     fn unwrap_mut<'a, 'b>(vec: &'b mut AnyVec<'a>) -> &'b mut Vec<u64> where u64: 'a { vec.cast_ref_mut_u64() }
     fn wrap_one(value: u64) -> RawVal { RawVal::Int(value as i64) }
-    fn t() -> EncodingType { EncodingType::I64 }
+    fn t() -> EncodingType { EncodingType::U64 }
 }
 
 impl GenericVec<usize> for usize {
@@ -300,9 +300,9 @@ impl<'c> GenericVec<&'c str> for &'c str {
 }
 
 
-pub trait GenericIntVec<T>: GenericVec<T> + Into<i64> + IntoUsize + PrimInt + Hash + 'static {}
+pub trait GenericIntVec<T>: GenericVec<T> + CastUsize + PrimInt + Hash + 'static {}
 
-impl<T> GenericIntVec<T> for T where T: GenericVec<T> + Into<i64> + IntoUsize + PrimInt + Copy + Hash + 'static {}
+impl<T> GenericIntVec<T> for T where T: GenericVec<T> + CastUsize + PrimInt + Copy + Hash + 'static {}
 
 pub trait ConstType<T> {
     fn unwrap(vec: &AnyVec) -> T;
@@ -317,26 +317,29 @@ impl ConstType<String> for String {
 }
 
 
-pub trait IntoUsize {
+pub trait CastUsize {
     fn cast_usize(&self) -> usize;
 }
 
-impl IntoUsize for u8 {
+impl CastUsize for u8 {
     fn cast_usize(&self) -> usize { *self as usize }
 }
 
-impl IntoUsize for u16 {
+impl CastUsize for u16 {
     fn cast_usize(&self) -> usize { *self as usize }
 }
 
-impl IntoUsize for u32 {
+impl CastUsize for u32 {
     fn cast_usize(&self) -> usize { *self as usize }
 }
 
-impl IntoUsize for i64 {
+impl CastUsize for i64 {
     fn cast_usize(&self) -> usize { *self as usize }
 }
 
+impl CastUsize for u64 {
+    fn cast_usize(&self) -> usize { *self as usize }
+}
 
 #[derive(Debug, PartialEq, PartialOrd, Ord, Eq, Copy, Clone, HeapSizeOf)]
 pub enum MergeOp {

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -13,6 +13,7 @@ pub enum EncodingType {
     U8,
     U16,
     U32,
+    U64,
 
     Premerge,
     MergeOp,

--- a/src/engine/vector_op/addition_vs.rs
+++ b/src/engine/vector_op/addition_vs.rs
@@ -23,7 +23,7 @@ impl<'a, T: GenericIntVec<T>> VecOperator<'a> for AdditionVS<T> {
         }
     }
 
-    fn init(&mut self, _: usize, batch_size: usize, _: bool, scratchpad: &mut Scratchpad<'a>) {
+    fn init(&mut self, _: usize, batch_size: usize, scratchpad: &mut Scratchpad<'a>) {
         scratchpad.set(self.output, Box::new(Vec::<i64>::with_capacity(batch_size)));
     }
 

--- a/src/engine/vector_op/bit_unpack.rs
+++ b/src/engine/vector_op/bit_unpack.rs
@@ -32,7 +32,7 @@ impl<'a> VecOperator<'a> for BitUnpackOperator {
         }
     }
 
-    fn init(&mut self, _: usize, batch_size: usize, _: bool, scratchpad: &mut Scratchpad<'a>) {
+    fn init(&mut self, _: usize, batch_size: usize, scratchpad: &mut Scratchpad<'a>) {
         scratchpad.set(self.output, AnyVec::owned(Vec::<i64>::with_capacity(batch_size)));
     }
 

--- a/src/engine/vector_op/constant.rs
+++ b/src/engine/vector_op/constant.rs
@@ -13,7 +13,7 @@ pub struct Constant {
 impl<'a> VecOperator<'a> for Constant {
     fn execute(&mut self, _: bool, _: &mut Scratchpad<'a>) {}
 
-    fn init(&mut self, _: usize, _: usize, _: bool, scratchpad: &mut Scratchpad<'a>) {
+    fn init(&mut self, _: usize, _: usize, scratchpad: &mut Scratchpad<'a>) {
         let result = AnyVec::constant(self.val.clone());
         scratchpad.set(self.output, result);
     }

--- a/src/engine/vector_op/constant_vec.rs
+++ b/src/engine/vector_op/constant_vec.rs
@@ -13,7 +13,7 @@ pub struct ConstantVec<'a> {
 impl<'a> VecOperator<'a> for ConstantVec<'a> {
     fn execute(&mut self, _: bool, _: &mut Scratchpad<'a>) {}
 
-    fn init(&mut self, _: usize, _: usize, _: bool, scratchpad: &mut Scratchpad<'a>) {
+    fn init(&mut self, _: usize, _: usize, scratchpad: &mut Scratchpad<'a>) {
         let owned = mem::replace(&mut self.val, AnyVec::empty(0));
         scratchpad.set(self.output, owned);
     }

--- a/src/engine/vector_op/count.rs
+++ b/src/engine/vector_op/count.rs
@@ -24,7 +24,7 @@ impl<T> VecCount<T> {
     }
 }
 
-impl<'a, T: GenericIntVec<T> + IntoUsize> VecOperator<'a> for VecCount<T> {
+impl<'a, T: GenericIntVec<T> + CastUsize> VecOperator<'a> for VecCount<T> {
     fn execute(&mut self, _: bool, scratchpad: &mut Scratchpad<'a>) {
         let mut result = scratchpad.get_mut::<u32>(self.output);
         let grouping = scratchpad.get::<T>(self.grouping);
@@ -39,7 +39,7 @@ impl<'a, T: GenericIntVec<T> + IntoUsize> VecOperator<'a> for VecCount<T> {
         }
     }
 
-    fn init(&mut self, _: usize, _: usize, _: bool, scratchpad: &mut Scratchpad<'a>) {
+    fn init(&mut self, _: usize, _: usize, scratchpad: &mut Scratchpad<'a>) {
         scratchpad.set(self.output, AnyVec::owned(Vec::<u32>::with_capacity(0)));
     }
 

--- a/src/engine/vector_op/dict_lookup.rs
+++ b/src/engine/vector_op/dict_lookup.rs
@@ -36,7 +36,7 @@ impl<'a, T: GenericIntVec<T>> VecOperator<'a> for DictLookup<T> {
         }
     }
 
-    fn init(&mut self, _: usize, batch_size: usize, _: bool, scratchpad: &mut Scratchpad<'a>) {
+    fn init(&mut self, _: usize, batch_size: usize, scratchpad: &mut Scratchpad<'a>) {
         scratchpad.set(self.output, Box::new(Vec::<&str>::with_capacity(batch_size)));
     }
 

--- a/src/engine/vector_op/division_vs.rs
+++ b/src/engine/vector_op/division_vs.rs
@@ -19,7 +19,7 @@ impl<'a> VecOperator<'a> for DivideVS {
         }
     }
 
-    fn init(&mut self, _: usize, batch_size: usize, _: bool, scratchpad: &mut Scratchpad<'a>) {
+    fn init(&mut self, _: usize, batch_size: usize, scratchpad: &mut Scratchpad<'a>) {
         scratchpad.set(self.output, Box::new(Vec::<i64>::with_capacity(batch_size)));
     }
 

--- a/src/engine/vector_op/encode_const.rs
+++ b/src/engine/vector_op/encode_const.rs
@@ -12,7 +12,7 @@ pub struct EncodeIntConstant {
 impl<'a> VecOperator<'a> for EncodeIntConstant {
     fn execute(&mut self, _: bool, _: &mut Scratchpad<'a>) {}
 
-    fn init(&mut self, _: usize, _: usize, _: bool, scratchpad: &mut Scratchpad<'a>) {
+    fn init(&mut self, _: usize, _: usize, scratchpad: &mut Scratchpad<'a>) {
         let constant = scratchpad.get_const::<i64>(self.constant);
         let result = self.codec.encode_int(constant);
         scratchpad.set(self.output, AnyVec::constant(result));

--- a/src/engine/vector_op/exists.rs
+++ b/src/engine/vector_op/exists.rs
@@ -12,13 +12,13 @@ pub struct Exists<T> {
     t: PhantomData<T>,
 }
 
-impl<T: GenericIntVec<T> + IntoUsize> Exists<T> {
+impl<T: GenericIntVec<T> + CastUsize> Exists<T> {
     pub fn boxed<'a>(input: BufferRef, output: BufferRef, max_index: BufferRef) -> BoxedOperator<'a> {
         Box::new(Exists::<T> { input, output, max_index, t: PhantomData })
     }
 }
 
-impl<'a, T: GenericIntVec<T> + IntoUsize> VecOperator<'a> for Exists<T> {
+impl<'a, T: GenericIntVec<T> + CastUsize> VecOperator<'a> for Exists<T> {
     fn execute(&mut self, _: bool, scratchpad: &mut Scratchpad<'a>) {
         let data = scratchpad.get::<T>(self.input);
         let mut exists = scratchpad.get_mut::<u8>(self.output);
@@ -34,7 +34,7 @@ impl<'a, T: GenericIntVec<T> + IntoUsize> VecOperator<'a> for Exists<T> {
         }
     }
 
-    fn init(&mut self, _: usize, _: usize, _: bool, scratchpad: &mut Scratchpad<'a>) {
+    fn init(&mut self, _: usize, _: usize, scratchpad: &mut Scratchpad<'a>) {
         scratchpad.set(self.output, AnyVec::owned(Vec::<u8>::with_capacity(0)));
     }
 

--- a/src/engine/vector_op/filter.rs
+++ b/src/engine/vector_op/filter.rs
@@ -28,7 +28,7 @@ impl<'a, T: 'a> VecOperator<'a> for Filter<T> where T: GenericVec<T> {
         trace!("filtered: {:?}", filtered);
     }
 
-    fn init(&mut self, _: usize, batch_size: usize, _: bool, scratchpad: &mut Scratchpad<'a>) {
+    fn init(&mut self, _: usize, batch_size: usize, scratchpad: &mut Scratchpad<'a>) {
         scratchpad.set(self.output, AnyVec::owned(Vec::<T>::with_capacity(batch_size)));
     }
 

--- a/src/engine/vector_op/hashmap_grouping.rs
+++ b/src/engine/vector_op/hashmap_grouping.rs
@@ -15,7 +15,7 @@ pub struct HashMapGrouping<T: GenericIntVec<T>> {
     map: FnvHashMap<T, T>,
 }
 
-impl<T: GenericIntVec<T> + IntoUsize> HashMapGrouping<T> {
+impl<T: GenericIntVec<T> + CastUsize> HashMapGrouping<T> {
     pub fn boxed<'a>(input: BufferRef,
                      unique_out: BufferRef,
                      grouping_key_out: BufferRef,
@@ -31,7 +31,7 @@ impl<T: GenericIntVec<T> + IntoUsize> HashMapGrouping<T> {
     }
 }
 
-impl<'a, T: GenericIntVec<T> + IntoUsize> VecOperator<'a> for HashMapGrouping<T> {
+impl<'a, T: GenericIntVec<T> + CastUsize> VecOperator<'a> for HashMapGrouping<T> {
     fn execute(&mut self, stream: bool, scratchpad: &mut Scratchpad<'a>) {
         let count = {
             let raw_grouping_key = scratchpad.get::<T>(self.input);
@@ -49,7 +49,7 @@ impl<'a, T: GenericIntVec<T> + IntoUsize> VecOperator<'a> for HashMapGrouping<T>
         scratchpad.set(self.cardinality_out, AnyVec::constant(count));
     }
 
-    fn init(&mut self, _: usize, batch_size: usize, _: bool, scratchpad: &mut Scratchpad<'a>) {
+    fn init(&mut self, _: usize, batch_size: usize, scratchpad: &mut Scratchpad<'a>) {
         // TODO(clemens): Estimate capacities for unique + map?
         scratchpad.set(self.unique_out, AnyVec::owned(Vec::<T>::new()));
         scratchpad.set(self.grouping_key_out, AnyVec::owned(Vec::<T>::with_capacity(batch_size)));

--- a/src/engine/vector_op/lz4_decode.rs
+++ b/src/engine/vector_op/lz4_decode.rs
@@ -1,0 +1,57 @@
+use std::marker::PhantomData;
+use std::io::Read;
+use std::fmt;
+use std::mem;
+
+use engine::*;
+use engine::vector_op::vector_operator::*;
+use mem_store::lz4;
+
+
+pub struct LZ4Decode<'a, T> {
+    pub encoded: BufferRef,
+    pub decoded: BufferRef,
+    pub reader: Box<Read + 'a>,
+    pub has_more: bool,
+    pub t: PhantomData<T>,
+}
+
+impl<'a, T: GenericIntVec<T>> VecOperator<'a> for LZ4Decode<'a, T> {
+    fn execute(&mut self, _: bool, scratchpad: &mut Scratchpad<'a>) {
+        let mut decoded = scratchpad.get_mut::<T>(self.decoded);
+        let len = unsafe { lz4::decode(&mut self.reader, &mut decoded) };
+        if len < decoded.len() {
+            decoded.truncate(len);
+            self.has_more = false;
+        }
+    }
+
+    fn init(&mut self, _: usize, batch_size: usize, scratchpad: &mut Scratchpad<'a>) {
+        scratchpad.set(self.decoded, Box::new(vec![T::zero(); batch_size]));
+        let encoded = scratchpad.get::<u8>(self.encoded);
+        // TODO(clemens): eliminate unsafe? could store in scratchpad...
+        self.reader = unsafe {
+            let decoder: Box<Read> = Box::new(lz4::decoder(encoded.as_ref()));
+            mem::transmute::<_, Box<Read + 'a>>(decoder)
+        };
+    }
+
+    fn inputs(&self) -> Vec<BufferRef> { vec![self.encoded] }
+    fn outputs(&self) -> Vec<BufferRef> { vec![self.decoded] }
+    fn can_stream_input(&self, _: BufferRef) -> bool { false }
+    fn can_stream_output(&self, _: BufferRef) -> bool { true }
+    fn allocates(&self) -> bool { true }
+    fn is_streaming_producer(&self) -> bool { true }
+    fn has_more(&self) -> bool { self.has_more }
+
+    fn display_op(&self, _: bool) -> String {
+        format!("lz4_decode({})", self.encoded)
+    }
+}
+
+impl<'a, T> fmt::Debug for LZ4Decode<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "LZ4Decode {{ encoded: {}, decoded: {} }}", self.encoded, self.decoded)
+    }
+}
+

--- a/src/engine/vector_op/mod.rs
+++ b/src/engine/vector_op/mod.rs
@@ -31,6 +31,8 @@ mod to_year;
 mod top_n;
 mod type_conversion;
 mod vec_const_bool_op;
+#[cfg(feature = "enable_lz4")]
+mod lz4_decode;
 pub mod merge_deduplicate_partitioned;
 pub mod partition;
 pub mod subpartition;

--- a/src/engine/vector_op/nonzero_indices.rs
+++ b/src/engine/vector_op/nonzero_indices.rs
@@ -13,13 +13,13 @@ pub struct NonzeroIndices<T, U> {
     u: PhantomData<U>,
 }
 
-impl<T: GenericIntVec<T> + IntoUsize, U: GenericIntVec<U>> NonzeroIndices<T, U> {
+impl<T: GenericIntVec<T> + CastUsize, U: GenericIntVec<U>> NonzeroIndices<T, U> {
     pub fn boxed<'a>(input: BufferRef, output: BufferRef) -> BoxedOperator<'a> {
         Box::new(NonzeroIndices::<T, U> { input, output, t: PhantomData, u: PhantomData })
     }
 }
 
-impl<'a, T: GenericIntVec<T> + IntoUsize, U: GenericIntVec<U>> VecOperator<'a> for NonzeroIndices<T, U> {
+impl<'a, T: GenericIntVec<T> + CastUsize, U: GenericIntVec<U>> VecOperator<'a> for NonzeroIndices<T, U> {
     fn execute(&mut self, _: bool, scratchpad: &mut Scratchpad<'a>) {
         let exists = scratchpad.get::<T>(self.input);
         let mut unique = scratchpad.get_mut::<U>(self.output);
@@ -30,7 +30,7 @@ impl<'a, T: GenericIntVec<T> + IntoUsize, U: GenericIntVec<U>> VecOperator<'a> f
         }
     }
 
-    fn init(&mut self, _: usize, _: usize, _: bool, scratchpad: &mut Scratchpad<'a>) {
+    fn init(&mut self, _: usize, _: usize, scratchpad: &mut Scratchpad<'a>) {
         // TODO(clemens): output size estimate?
         scratchpad.set(self.output, AnyVec::owned(Vec::<U>::new()));
     }

--- a/src/engine/vector_op/parameterized_vec_vec_int_op.rs
+++ b/src/engine/vector_op/parameterized_vec_vec_int_op.rs
@@ -37,7 +37,7 @@ impl<'a, Op: ParameterizedIntegerOperation + fmt::Debug> VecOperator<'a> for Par
         }
     }
 
-    fn init(&mut self, _: usize, batch_size: usize, _: bool, scratchpad: &mut Scratchpad<'a>) {
+    fn init(&mut self, _: usize, batch_size: usize, scratchpad: &mut Scratchpad<'a>) {
         scratchpad.set(self.output, AnyVec::owned(Vec::<i64>::with_capacity(batch_size)));
     }
 

--- a/src/engine/vector_op/select.rs
+++ b/src/engine/vector_op/select.rs
@@ -23,7 +23,7 @@ impl<'a, T: 'a> VecOperator<'a> for Select<T> where T: GenericVec<T> {
         }
     }
 
-    fn init(&mut self, _: usize, batch_size: usize, _: bool, scratchpad: &mut Scratchpad<'a>) {
+    fn init(&mut self, _: usize, batch_size: usize, scratchpad: &mut Scratchpad<'a>) {
         scratchpad.set(self.output, AnyVec::owned(Vec::<T>::with_capacity(batch_size)));
     }
 

--- a/src/engine/vector_op/sum.rs
+++ b/src/engine/vector_op/sum.rs
@@ -16,7 +16,7 @@ pub struct VecSum<T, U> {
 }
 
 impl<T, U> VecSum<T, U> where
-    T: GenericIntVec<T>, U: GenericIntVec<U> + IntoUsize {
+    T: GenericIntVec<T> + Into<i64>, U: GenericIntVec<U> + CastUsize {
     pub fn boxed<'a>(input: BufferRef, grouping: BufferRef, output: BufferRef, max_index: BufferRef) -> BoxedOperator<'a> {
         Box::new(VecSum::<T, U> {
             input,
@@ -30,7 +30,7 @@ impl<T, U> VecSum<T, U> where
 }
 
 impl<'a, T, U> VecOperator<'a> for VecSum<T, U> where
-    T: GenericIntVec<T>, U: GenericIntVec<U> {
+    T: GenericIntVec<T> + Into<i64>, U: GenericIntVec<U> {
     fn execute(&mut self, _: bool, scratchpad: &mut Scratchpad<'a>) {
         let nums = scratchpad.get::<T>(self.input);
         let grouping = scratchpad.get::<U>(self.grouping);
@@ -46,7 +46,7 @@ impl<'a, T, U> VecOperator<'a> for VecSum<T, U> where
         }
     }
 
-    fn init(&mut self, _: usize, _: usize, _: bool, scratchpad: &mut Scratchpad<'a>) {
+    fn init(&mut self, _: usize, _: usize, scratchpad: &mut Scratchpad<'a>) {
         scratchpad.set(self.output, AnyVec::owned(Vec::<i64>::with_capacity(0)));
     }
 

--- a/src/engine/vector_op/to_year.rs
+++ b/src/engine/vector_op/to_year.rs
@@ -19,7 +19,7 @@ impl<'a> VecOperator<'a> for ToYear {
         }
     }
 
-    fn init(&mut self, _: usize, batch_size: usize, _: bool, scratchpad: &mut Scratchpad<'a>) {
+    fn init(&mut self, _: usize, batch_size: usize, scratchpad: &mut Scratchpad<'a>) {
         scratchpad.set(self.output, Box::new(Vec::<i64>::with_capacity(batch_size)));
     }
 

--- a/src/engine/vector_op/top_n.rs
+++ b/src/engine/vector_op/top_n.rs
@@ -21,7 +21,7 @@ pub struct TopN<T, C> {
 }
 
 impl<'a, T: GenericVec<T> + 'a, C: Comparator<T> + fmt::Debug> VecOperator<'a> for TopN<T, C> {
-    fn init(&mut self, _: usize, _: usize, _: bool, scratchpad: &mut Scratchpad<'a>) {
+    fn init(&mut self, _: usize, _: usize, scratchpad: &mut Scratchpad<'a>) {
         scratchpad.set(self.indices, AnyVec::owned(Vec::<usize>::with_capacity(self.n)));
         scratchpad.set(self.keys, AnyVec::owned(Vec::<T>::with_capacity(self.n)));
     }

--- a/src/engine/vector_op/type_conversion.rs
+++ b/src/engine/vector_op/type_conversion.rs
@@ -34,7 +34,7 @@ impl<'a, T: 'a, U: 'a> VecOperator<'a> for TypeConversionOperator<T, U> where
         }
     }
 
-    fn init(&mut self, _: usize, batch_size: usize, _: bool, scratchpad: &mut Scratchpad<'a>) {
+    fn init(&mut self, _: usize, batch_size: usize, scratchpad: &mut Scratchpad<'a>) {
         scratchpad.set(self.output, Box::new(Vec::<U>::with_capacity(batch_size)));
     }
 

--- a/src/engine/vector_op/vec_const_bool_op.rs
+++ b/src/engine/vector_op/vec_const_bool_op.rs
@@ -40,7 +40,7 @@ impl<'a, T: 'a, U, Op> VecOperator<'a> for VecConstBoolOperator<T, U, Op> where
         }
     }
 
-    fn init(&mut self, _: usize, batch_size: usize, _: bool, scratchpad: &mut Scratchpad<'a>) {
+    fn init(&mut self, _: usize, batch_size: usize, scratchpad: &mut Scratchpad<'a>) {
         scratchpad.set(self.output, AnyVec::owned(Vec::<u8>::with_capacity(batch_size)));
     }
 

--- a/src/mem_store/codec.rs
+++ b/src/mem_store/codec.rs
@@ -12,6 +12,7 @@ pub struct Codec {
     is_summation_preserving: bool,
     is_order_preserving: bool,
     is_positive_integer: bool,
+    is_fixed_width: bool,
 }
 
 impl Codec {
@@ -21,9 +22,10 @@ impl Codec {
             _ => true
         }).unwrap().input_type();
         let decoded_type = ops[ops.len() - 1].output_type();
-        let is_summation_preserving = ops.iter().all(|x| x.is_summation_preserving());
-        let is_order_preserving = ops.iter().all(|x| x.is_order_preserving());
-        let is_positive_integer = ops.iter().all(|x| x.is_positive_integer());
+        let is_summation_preserving = Codec::has_property(&ops, CodecOp::is_summation_preserving);
+        let is_order_preserving = Codec::has_property(&ops, CodecOp::is_order_preserving);
+        let is_positive_integer = Codec::has_property(&ops, CodecOp::is_positive_integer);
+        let is_fixed_width = Codec::has_property(&ops, CodecOp::is_fixed_width);
         Codec {
             ops,
             column_name: "COLUMN_UNSPECIFIED".to_string(),
@@ -32,26 +34,41 @@ impl Codec {
             is_summation_preserving,
             is_order_preserving,
             is_positive_integer,
+            is_fixed_width,
         }
     }
 
-    pub fn identity(t: EncodingType) -> Codec {
+    pub fn identity(t: BasicType) -> Codec {
         Codec {
             ops: vec![],
             column_name: "COLUMN_UNSPECIFIED".to_string(),
-            encoding_type: t,
-            decoded_type: t.cast_to_basic(),
+            encoding_type: t.to_encoded(),
+            decoded_type: t,
             is_summation_preserving: true,
             is_order_preserving: true,
             is_positive_integer: true,
+            is_fixed_width: true,
         }
+    }
+
+    pub fn integer_offset(t: EncodingType, offset: i64) -> Codec {
+        Codec::new(vec![CodecOp::Add(t, offset)])
+    }
+
+    pub fn integer_cast(t: EncodingType) -> Codec {
+        Codec::new(vec![CodecOp::ToI64(t)])
+    }
+
+    pub fn lz4(t: EncodingType) -> Codec {
+        Codec::new(vec![CodecOp::LZ4(t)])
     }
 
     pub fn opaque(encoding_type: EncodingType,
                   decoded_type: BasicType,
                   is_summation_preserving: bool,
                   is_order_preserving: bool,
-                  is_positive_integer: bool) -> Codec {
+                  is_positive_integer: bool,
+                  is_fixed_width: bool) -> Codec {
         Codec {
             ops: vec![CodecOp::Unknown],
             column_name: "COLUMN_UNSPECIFIED".to_string(),
@@ -60,12 +77,34 @@ impl Codec {
             is_summation_preserving,
             is_order_preserving,
             is_positive_integer,
+            is_fixed_width,
         }
     }
 
+    pub fn with_lz4(&self) -> Codec {
+        let mut ops = vec![CodecOp::LZ4(self.encoding_type)];
+        for &op in &self.ops {
+            /*match  op {
+                CodecOp::DictLookup(t)=>{
+                    let dict_data  = ops.pop().unwrap();
+                    let dict_indices = ops.pop().unwrap();
+                    ops.push(CodecOp::LZ4(EncodingType::U8));
+                    ops.push(dict_indices);
+                    ops.push(CodecOp::LZ4())
+                }
+            }*/
+            ops.push(op);
+        }
+        Codec::new(ops)
+    }
+
     pub fn decode(&self, plan: Box<QueryPlan>) -> Box<QueryPlan> {
+        self.decode_ops(&self.ops, plan)
+    }
+
+    fn decode_ops(&self, ops: &[CodecOp], plan: Box<QueryPlan>) -> Box<QueryPlan> {
         let mut stack = vec![plan];
-        for op in &self.ops {
+        for op in ops {
             let plan = match *op {
                 CodecOp::Add(t, x) => {
                     Box::new(QueryPlan::AddVS(
@@ -74,7 +113,7 @@ impl Codec {
                         Box::new(QueryPlan::Constant(RawVal::Int(x), true))))
                 }
                 CodecOp::ToI64(t) => {
-                    Box::new(QueryPlan::TypeConversion(
+                    Box::new(QueryPlan::Widen(
                         stack.pop().unwrap(),
                         t,
                         EncodingType::I64))
@@ -95,6 +134,9 @@ impl Codec {
                         dict_indices,
                         dict_data))
                 }
+                CodecOp::LZ4(t) =>
+                    Box::new(QueryPlan::LZ4Decode(
+                        stack.pop().unwrap(), t)),
                 CodecOp::UnpackStrings => unimplemented!(" unpack strings"),
                 CodecOp::Unknown => panic!("unkown decode plan!"),
             };
@@ -103,11 +145,24 @@ impl Codec {
         assert_eq!(stack.len(), 1);
         stack.pop().unwrap()
     }
+
+    pub fn ensure_fixed_width(&self, plan: Box<QueryPlan>) -> (Codec, Box<QueryPlan>) {
+        let (fixed_width, rest) = self.ensure_property(CodecOp::is_fixed_width);
+        let mut new_codec = if rest.is_empty() {
+            Codec::identity(self.decoded_type())
+        } else {
+            Codec::new(rest)
+        };
+        new_codec.set_column_name(&self.column_name);
+        (new_codec, self.decode_ops(&fixed_width, plan))
+    }
+
     pub fn encoding_type(&self) -> EncodingType { self.encoding_type }
     pub fn decoded_type(&self) -> BasicType { self.decoded_type }
     pub fn is_summation_preserving(&self) -> bool { self.is_summation_preserving }
     pub fn is_order_preserving(&self) -> bool { self.is_order_preserving }
     pub fn is_positive_integer(&self) -> bool { self.is_positive_integer }
+    pub fn is_fixed_width(&self) -> bool { self.is_fixed_width }
 
     pub fn encode_str(&self, string_const: Box<QueryPlan>) -> Box<QueryPlan> {
         match self.ops[..] {
@@ -137,14 +192,64 @@ impl Codec {
     pub(in mem_store) fn set_column_name(&mut self, name: &str) {
         self.column_name = name.to_string();
     }
+
+
+    fn has_property(ops: &[CodecOp], p: fn(&CodecOp) -> bool) -> bool {
+        let mut ops = ops.to_vec();
+        while let Some(op) = ops.pop() {
+            if !p(&op) { return false; }
+            for _ in 1..op.arg_count() {
+                Codec::pop(&mut ops);
+            }
+        }
+        true
+    }
+
+    fn pop(ops: &mut Vec<CodecOp>) {
+        if let Some(op) = ops.pop() {
+            for _ in 0..op.arg_count() {
+                Codec::pop(ops);
+            }
+        }
+    }
+
+    /// Splits up the CodecOps into two sequences.
+    /// The first sequence is the minimum number of `CodecOp`s that have to be executed to restore property `p`.
+    /// The second sequence is the remaining operations required for full decoding.
+    fn ensure_property(&self, p: fn(&CodecOp) -> bool) -> (Vec<CodecOp>, Vec<CodecOp>) {
+        let mut ops = self.ops.clone();
+        let mut property_preserving = Vec::new();
+        while let Some(op) = ops.pop() {
+            if !p(&op) {
+                ops.push(op);
+                property_preserving.reverse();
+                return (ops, property_preserving);
+            }
+            property_preserving.push(op);
+            for _ in 1..op.arg_count() {
+                Codec::pop_push(&mut ops, &mut property_preserving);
+            }
+        }
+        (ops, property_preserving)
+    }
+
+    fn pop_push(ops: &mut Vec<CodecOp>, push: &mut Vec<CodecOp>) {
+        if let Some(op) = ops.pop() {
+            push.push(op);
+            for _ in 0..op.arg_count() {
+                Codec::pop_push(ops, push);
+            }
+        }
+    }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, HeapSizeOf)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, HeapSizeOf)]
 pub enum CodecOp {
     Add(EncodingType, i64),
     ToI64(EncodingType),
     PushDataSection(usize),
     DictLookup(EncodingType),
+    LZ4(EncodingType),
     UnpackStrings,
     Unknown,
 }
@@ -155,8 +260,10 @@ impl CodecOp {
             CodecOp::Add(t, _) => t,
             CodecOp::ToI64(t) => t,
             CodecOp::DictLookup(t) => t,
+            CodecOp::LZ4(_) => EncodingType::U8,
             CodecOp::UnpackStrings => EncodingType::U8,
-            _ => panic!("{:?}.input_type()", self),
+            CodecOp::PushDataSection(_) => panic!("PushDataSection.input_type()"),
+            CodecOp::Unknown => panic!("Unknown.input_type()"),
         }
     }
 
@@ -165,8 +272,10 @@ impl CodecOp {
             CodecOp::Add(_, _) => BasicType::Integer,
             CodecOp::ToI64(_) => BasicType::Integer,
             CodecOp::DictLookup(_) => BasicType::String,
+            CodecOp::LZ4(_) => BasicType::Integer,
             CodecOp::UnpackStrings => BasicType::String,
-            _ => panic!("{:?}.input_type()", self),
+            CodecOp::PushDataSection(_) => panic!("PushDataSection.input_type()"),
+            CodecOp::Unknown => panic!("Unknown.output_type()"),
         }
     }
 
@@ -176,6 +285,7 @@ impl CodecOp {
             CodecOp::ToI64(_) => true,
             CodecOp::PushDataSection(_) => true,
             CodecOp::DictLookup(_) => false,
+            CodecOp::LZ4(_) => false,
             CodecOp::UnpackStrings => false,
             CodecOp::Unknown => panic!("Unknown.is_summation_preserving()"),
         }
@@ -187,6 +297,7 @@ impl CodecOp {
             CodecOp::ToI64(_) => true,
             CodecOp::PushDataSection(_) => true,
             CodecOp::DictLookup(_) => true,
+            CodecOp::LZ4(_) => false,
             CodecOp::UnpackStrings => false,
             CodecOp::Unknown => panic!("Unknown.is_summation_preserving()"),
         }
@@ -195,13 +306,65 @@ impl CodecOp {
     fn is_positive_integer(&self) -> bool {
         match self {
             CodecOp::Add(_, _) => true,
+            CodecOp::ToI64(_) => true, // TODO(clemens): no it's not (hack to make grouping key work)
+            CodecOp::PushDataSection(_) => true,
+            CodecOp::DictLookup(_) => true,
+            CodecOp::LZ4(_) => false,
+            CodecOp::UnpackStrings => false,
+            CodecOp::Unknown => panic!("Unknown.is_positive_integer()"),
+        }
+    }
+
+    fn is_fixed_width(&self) -> bool {
+        match self {
+            CodecOp::Add(_, _) => true,
             CodecOp::ToI64(_) => true,
             CodecOp::PushDataSection(_) => true,
             CodecOp::DictLookup(_) => true,
+            CodecOp::LZ4(_) => false,
             CodecOp::UnpackStrings => false,
-            CodecOp::Unknown => panic!("Unknown.is_positive_integer()"),
+            CodecOp::Unknown => panic!("Unknown.is_fixed_width()"),
+        }
+    }
+
+    fn arg_count(&self) -> usize {
+        match self {
+            CodecOp::Add(_, _) => 1,
+            CodecOp::ToI64(_) => 1,
+            CodecOp::PushDataSection(_) => 0,
+            CodecOp::DictLookup(_) => 3,
+            CodecOp::LZ4(_) => 1,
+            CodecOp::UnpackStrings => 1,
+            CodecOp::Unknown => panic!("Unknown.is_fixed_width()"),
         }
     }
 }
 
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ensure_property() {
+        let codec = vec![
+            CodecOp::LZ4(EncodingType::U16),
+            CodecOp::PushDataSection(1),
+            CodecOp::LZ4(EncodingType::U64),
+            CodecOp::PushDataSection(2),
+            CodecOp::LZ4(EncodingType::U8),
+            CodecOp::DictLookup(EncodingType::U16),
+        ];
+        let (fixed_width, rest) = Codec::new(codec).ensure_property(CodecOp::is_fixed_width);
+        assert_eq!(fixed_width, vec![
+            CodecOp::LZ4(EncodingType::U16),
+        ]);
+        assert_eq!(rest, vec![
+            CodecOp::PushDataSection(1),
+            CodecOp::LZ4(EncodingType::U64),
+            CodecOp::PushDataSection(2),
+            CodecOp::LZ4(EncodingType::U8),
+            CodecOp::DictLookup(EncodingType::U16),
+        ]);
+    }
+}

--- a/src/mem_store/column.rs
+++ b/src/mem_store/column.rs
@@ -32,7 +32,7 @@ impl Column {
             name: name.to_string(),
             len,
             range: None,
-            codec: Codec::identity(EncodingType::Null),
+            codec: Codec::identity(BasicType::Null),
             data: vec![DataSection::Null(len)],
         }
     }
@@ -73,5 +73,25 @@ impl DataSection {
             DataSection::Null(ref x) => x,
         }
     }
+}
+
+impl From<Vec<u8>> for DataSection {
+    fn from(vec: Vec<u8>) -> Self { DataSection::U8(vec) }
+}
+
+impl From<Vec<u16>> for DataSection {
+    fn from(vec: Vec<u16>) -> Self { DataSection::U16(vec) }
+}
+
+impl From<Vec<u32>> for DataSection {
+    fn from(vec: Vec<u32>) -> Self { DataSection::U32(vec) }
+}
+
+impl From<Vec<u64>> for DataSection {
+    fn from(vec: Vec<u64>) -> Self { DataSection::U64(vec) }
+}
+
+impl From<Vec<i64>> for DataSection {
+    fn from(vec: Vec<i64>) -> Self { DataSection::I64(vec) }
 }
 

--- a/src/mem_store/integers.rs
+++ b/src/mem_store/integers.rs
@@ -11,53 +11,64 @@ pub struct IntegerColumn;
 
 impl IntegerColumn {
     pub fn new_boxed(name: &str, mut values: Vec<i64>, min: i64, max: i64) -> Arc<Column> {
-        let len = values.len();
         // TODO(clemens): remove, this was just a hack to vary memory bandwidth for benchmarks
         let min_width = env::var_os("LOCUSTDB_MIN_WIDTH")
             .map(|x| x.to_str().unwrap().parse::<u8>().unwrap()).unwrap_or(0);
-        let compressed_range = Some((0, max - min));
         let original_range = Some((min, max));
-        let (range, codec, data) = if min >= 0 && max <= From::from(u8::MAX) && min_width < 2 {
-            (original_range,
-             integer_cast_codec(EncodingType::U8),
-             DataSection::U8(IntegerColumn::encode::<u8>(values, 0)))
+        if min >= 0 && max <= From::from(u8::MAX) && min_width < 2 {
+            IntegerColumn::create_col::<u8>(name, values, 0, min, max, EncodingType::U8)
         } else if max - min <= From::from(u8::MAX) && min_width < 2 {
-            (compressed_range,
-             integer_offset_codec(EncodingType::U8, min),
-             DataSection::U8(IntegerColumn::encode::<u8>(values, min)))
+            IntegerColumn::create_col::<u8>(name, values, min, min, max, EncodingType::U8)
         } else if min >= 0 && max <= From::from(u16::MAX) && min_width < 3 {
-            (original_range,
-             integer_cast_codec(EncodingType::U16),
-             DataSection::U16(IntegerColumn::encode::<u16>(values, 0)))
+            IntegerColumn::create_col::<u16>(name, values, 0, min, max, EncodingType::U16)
         } else if max - min <= From::from(u16::MAX) && min_width < 3 {
-            (compressed_range,
-             integer_offset_codec(EncodingType::U16, min),
-             DataSection::U16(IntegerColumn::encode::<u16>(values, min)))
+            IntegerColumn::create_col::<u16>(name, values, min, min, max, EncodingType::U16)
         } else if min >= 0 && max <= From::from(u32::MAX) && min_width < 5 {
-            (original_range,
-             integer_cast_codec(EncodingType::U32),
-             DataSection::U32(IntegerColumn::encode::<u32>(values, 0)))
+            IntegerColumn::create_col::<u32>(name, values, 0, min, max, EncodingType::U32)
         } else if max - min <= From::from(u32::MAX) && min_width < 5 {
-            (compressed_range,
-             integer_offset_codec(EncodingType::U32, min),
-             DataSection::U32(IntegerColumn::encode::<u32>(values, min)))
+            IntegerColumn::create_col::<u32>(name, values, min, min, max, EncodingType::U32)
         } else {
             values.shrink_to_fit();
-            return Arc::new(Column::new(
-                name,
-                values.len(),
-                original_range,
-                Codec::identity(EncodingType::I64),
-                vec![DataSection::I64(values)]));
+            if cfg!(feature = "enable_lz4") {
+                Arc::new(Column::new(
+                    name,
+                    values.len(),
+                    original_range,
+                    Codec::lz4(EncodingType::I64),
+                    vec![DataSection::U8(unsafe { lz4::encode(&values) })]))
+            } else {
+                Arc::new(Column::new(
+                    name,
+                    values.len(),
+                    original_range,
+                    Codec::identity(BasicType::Integer),
+                    vec![DataSection::I64(values)]))
+            }
+        }
+    }
+
+    pub fn create_col<T>(name: &str, values: Vec<i64>, offset: i64, min: i64, max: i64, t: EncodingType) -> Arc<Column>
+        where T: GenericIntVec<T>, Vec<T>: Into<DataSection> {
+        let values = IntegerColumn::encode::<T>(values, offset);
+        let len = values.len();
+        let codec = if offset == 0 {
+            Codec::integer_cast(t)
+        } else {
+            Codec::integer_offset(t, offset)
         };
+
+        #[cfg(feature = "enable_lz4")]
+        let values = unsafe { lz4::encode(&values) };
+        #[cfg(feature = "enable_lz4")]
+        let codec = codec.with_lz4();
+
         Arc::new(Column::new(
             name,
             len,
-            range,
+            Some((min - offset, max - offset)),
             codec,
-            vec![data]))
+            vec![values.into()]))
     }
-
 
     pub fn encode<T: GenericIntVec<T>>(values: Vec<i64>, offset: i64) -> Vec<T> {
         let mut encoded_vals = Vec::with_capacity(values.len());
@@ -66,13 +77,5 @@ impl IntegerColumn {
         }
         encoded_vals
     }
-}
-
-pub fn integer_offset_codec(t: EncodingType, offset: i64) -> Codec {
-    Codec::new(vec![CodecOp::Add(t, offset)])
-}
-
-pub fn integer_cast_codec(t: EncodingType) -> Codec {
-    Codec::new(vec![CodecOp::ToI64(t)])
 }
 

--- a/src/mem_store/lz4.rs
+++ b/src/mem_store/lz4.rs
@@ -1,0 +1,61 @@
+extern crate lz4;
+
+use std::io::{Read, Write};
+use std::mem;
+use std::slice::{from_raw_parts, from_raw_parts_mut};
+use std::fmt::Debug;
+
+
+pub fn decoder(data: &[u8]) -> lz4::Decoder<&[u8]> {
+    lz4::Decoder::new(data).unwrap()
+}
+
+pub unsafe fn encode<T: Debug>(data: &[T]) -> Vec<u8> {
+    let ptr_t = data.as_ptr();
+    // Endianness? Never heard of it...
+    let ptr_u8 = mem::transmute::<_, *const u8>(ptr_t);
+    let data_u8: &[u8] = from_raw_parts(ptr_u8, data.len() * mem::size_of::<T>());
+
+    let mut result = Vec::new();
+    {
+        let mut encoder = lz4::EncoderBuilder::new().build(&mut result).unwrap();
+        encoder.write_all(data_u8).unwrap();
+        encoder.finish().1.unwrap();
+    }
+    result
+}
+
+pub unsafe fn decode<T>(src: &mut Read, dst: &mut [T]) -> usize {
+    let ptr_t = dst.as_ptr();
+    let ptr_u8 = mem::transmute::<_, *mut u8>(ptr_t);
+    let dst_u8: &mut [u8] = from_raw_parts_mut(ptr_u8, dst.len() * mem::size_of::<T>());
+
+    let mut read = 0;
+    // LZ4 decodes in blocks of at most 65536 elements, so might have to call multiple times to fill buffer
+    while read < dst_u8.len() && 0 != {
+        let len = src.read(&mut dst_u8[read..]).unwrap();
+        read += len;
+        len
+    } {}
+    if read % mem::size_of::<T>() != 0 {
+        println!("{} {} {} {}", dst.len(), dst_u8.len(), read, mem::size_of::<T>());
+    }
+    assert_eq!(read % mem::size_of::<T>(), 0);
+    read / mem::size_of::<T>()
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_decode() {
+        let data = vec![10i64, 12095, -51235, 3, 0, 0, 12353, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10];
+        let encoded = unsafe { encode(&data) };
+        let mut decoded = vec![0i64; data.len()];
+        let count = unsafe { decode(&mut decoder(&encoded), &mut decoded) };
+        assert_eq!(count, data.len());
+        assert_eq!(decoded, data);
+    }
+}

--- a/src/mem_store/mod.rs
+++ b/src/mem_store/mod.rs
@@ -7,8 +7,19 @@ pub mod table;
 pub mod raw_col;
 pub mod integers;
 pub mod strings;
+#[cfg(feature = "enable_lz4")]
+pub mod lz4;
 mod mixed_column;
 
 pub use self::column::{Column, DataSection};
 pub use self::codec::{Codec, CodecOp};
-pub use self::integers::{integer_cast_codec, integer_offset_codec};
+
+
+#[cfg(not(feature = "enable_lz4"))]
+pub mod lz4 {
+    use std::fmt::Debug;
+
+    pub unsafe fn encode<T: Debug>(_: &[T]) -> Vec<u8> {
+        panic!("lz4 not supported in this build of LocustDB. Recompile with --features enable_lz4.")
+    }
+}

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -273,7 +273,7 @@ fn test_restore_from_disk() {
         // Dropping the LocustDB object will cause all threads to be stopped
         // This eventually drops RocksDB and relinquish the file lock, however this happens asynchronously
         // TODO(clemens): make drop better
-        thread::sleep(time::Duration::from_millis(250));
+        thread::sleep(time::Duration::from_millis(1000));
     }
     let locustdb = LocustDB::disk_backed(tmp_dir.path().to_str().unwrap());
     let query = "select passenger_count, to_year(pickup_datetime), trip_distance / 1000, count(0) from default;";


### PR DESCRIPTION
Adds support for additional lz4 compression of data stored in memory and disk.

Perf for LZ4 encoded data in memory, and cold reads from disk:
```
1  0.34   0.41
2  1.1    7.9
3  0.79   13
4  3.9    20
5  2.2    21      
6  1.8    16
7  4.9    7.2
```
Queries same as in initial LocustDB blogpost.
Results collected under WSL and with a bunch of other programs running.