### PR TITLE
Group by single string column

### DIFF
--- a/src/engine/query_plan.rs
+++ b/src/engine/query_plan.rs
@@ -194,7 +194,7 @@ pub fn prepare_hashmap_grouping(raw_grouping_key: BufferRef,
         raw_grouping_key, unique_out, grouping_key_out, cardinality_out, grouping_key_type, max_cardinality));
     (Some(unique_out),
      grouping_key_out,
-     Type::encoded(Codec::opaque(grouping_key_type, BasicType::Integer, false, false, true, true)),
+     Type::encoded(Codec::opaque(EncodingType::U32, BasicType::Integer, false, false, true, true)),
      cardinality_out)
 }
 
@@ -427,7 +427,7 @@ impl QueryPlan {
                 .map(|(gk_plan, gk_type)| {
                     let max_cardinality = QueryPlan::encoding_range(&gk_plan).map_or(1 << 62, |i| i.1);
                     if QueryPlan::encoding_range(&gk_plan).is_none() {
-                        println!("Unknown range for {:?}", &gk_plan);
+                        warn!("Unknown range for {:?}", &gk_plan);
                     }
                     let decoded_group_by = gk_type.codec.clone().map_or(
                         QueryPlan::EncodedGroupByPlaceholder,

--- a/src/engine/vector_op/vector_operator.rs
+++ b/src/engine/vector_op/vector_operator.rs
@@ -480,6 +480,7 @@ impl<'a> VecOperator<'a> {
             EncodingType::U16 => HashMapGrouping::<u16>::boxed(raw_grouping_key, unique_out, grouping_key_out, cardinality_out, max_cardinality),
             EncodingType::U32 => HashMapGrouping::<u32>::boxed(raw_grouping_key, unique_out, grouping_key_out, cardinality_out, max_cardinality),
             EncodingType::I64 => HashMapGrouping::<i64>::boxed(raw_grouping_key, unique_out, grouping_key_out, cardinality_out, max_cardinality),
+            EncodingType::Str => HashMapGrouping::<&str>::boxed(raw_grouping_key, unique_out, grouping_key_out, cardinality_out, max_cardinality),
             t => panic!("unsupported type {:?} for grouping key", t),
         }
     }

--- a/src/mem_store/column_builder.rs
+++ b/src/mem_store/column_builder.rs
@@ -24,7 +24,7 @@ impl Default for StringColBuilder {
     fn default() -> StringColBuilder {
         StringColBuilder {
             data: Vec::new(),
-            uniques: UniqueValues::new(1 << 19),// TODO(clemens): use partition size
+            uniques: UniqueValues::new(1 << 22), // TODO(clemens): Limit?
         }
     }
 }


### PR DESCRIPTION
Make group by clauses work for single string columns, even when not
dictionary encoded.
Add tests + new column generators for string data.
Various smaller improvements and bugfixes.