### PR TITLE
replaced nom parser with sqlparser-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -144,10 +144,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chrono"
-version = "0.4.0"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -248,7 +249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -470,7 +471,7 @@ dependencies = [
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnp 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -486,7 +487,7 @@ dependencies = [
  "heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lz4 1.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -499,6 +500,7 @@ dependencies = [
  "rustyline 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sqlparser 0.1.6-alpha.0 (git+https://github.com/virattara/sqlparser-rs.git)",
  "std-semaphore 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -506,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.1"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -900,6 +902,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlparser"
+version = "0.1.6-alpha.0"
+source = "git+https://github.com/virattara/sqlparser-rs.git#891dc5a0f81008ab99c1dd342c2351ace5ecdae1"
+dependencies = [
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "std-semaphore"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1045,11 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "uuid"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,7 +1123,7 @@ dependencies = [
 "checksum cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "49ec142f5768efb5b7622aebc3fdbdbb8950a4b9ba996393cb76ef7466e8747d"
 "checksum cexpr 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42aac45e9567d97474a834efdee3081b3c942b2205be932092f53354ce503d6c"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
-"checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
+"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clang-sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7f7c04e52c35222fffcc3a115b5daf5f7e2bfb71c13c4e2321afe1fc71859c2"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
@@ -1144,7 +1161,7 @@ dependencies = [
 "checksum libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)" = "f54263ad99207254cf58b5f701ecb432c717445ea2ee8af387334bdd1a03fdff"
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
 "checksum librocksdb-sys 5.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "474d805d72e23a06310fa5201dfe182dc4b80ab1f18bb2823c1ac17ff9dcbaa2"
-"checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
+"checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
 "checksum lru 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "5fb41c1934bda881f2ab7ad8afa2ec25b8e0453563bfb09854bf3c319b1c96c3"
 "checksum lz4 1.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fe55d2ebbc2e4fc987e6fbfc13f416d97b06d06e50bc1124d613aa790842f80c"
 "checksum lz4-sys 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a59044c3ba3994f3d2aa2270ddd6c5947922219501e67efde5604d36aad462b5"
@@ -1193,6 +1210,7 @@ dependencies = [
 "checksum seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e048636bed25842fcdc36e5ad1ec6295b72d4b5b8a4b759b64915a4ce2b9d09d"
 "checksum serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)" = "0c3adf19c07af6d186d91dae8927b83b0553d07ca56cbf7f2f32560455c91920"
 "checksum skeptic 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd7d8dc1315094150052d0ab767840376335a98ac66ef313ff911cdf439a5b69"
+"checksum sqlparser 0.1.6-alpha.0 (git+https://github.com/virattara/sqlparser-rs.git)" = "<none>"
 "checksum std-semaphore 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33ae9eec00137a8eed469fb4148acd9fc6ac8c3f9b110f52cd34698c8b5bfa0e"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
@@ -1211,6 +1229,7 @@ dependencies = [
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+"checksum uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dab5c5526c5caa3d106653401a267fed923e7046f35895ffcb5ca42db64942e6"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum which 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e84a603e7e0b1ce1aa1ee2b109c7be00155ce52df5081590d1ffb93f4f515cb2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ time = "0.1.36"
 seahash = "3.0.5"
 bit-vec = "0.4.4"
 num_cpus = "1.0"
-chrono = "0.4.0"
+chrono = "0.4.6"
 failure = "0.1.1"
 failure_derive = "0.1.1"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
@@ -50,4 +50,4 @@ hex = "0.3.2"
 std-semaphore = "0.1.0"
 aliasmethod = "0.1.0"
 rand = "0.5.5"
-
+sqlparser = { git = "https://github.com/virattara/sqlparser-rs.git" }

--- a/src/bin/repl/main.rs
+++ b/src/bin/repl/main.rs
@@ -9,6 +9,7 @@ extern crate rustyline;
 extern crate time;
 extern crate env_logger;
 extern crate log;
+extern crate sqlparser;
 
 use failure::Fail;
 use futures_executor::block_on;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(fn_traits, integer_atomics, refcell_replace_swap, specialization, trait_alias, core_intrinsics, box_patterns, int_to_from_bytes, tool_lints)]
-#[macro_use]
-extern crate nom;
+extern crate sqlparser;
 #[macro_use]
 extern crate failure_derive;
 #[macro_use]

--- a/src/locustdb.rs
+++ b/src/locustdb.rs
@@ -45,9 +45,9 @@ impl LocustDB {
         let query = match parser::parse_query(query) {
             Ok(query) => query,
             Err(err) => {
-                return Box::new(future::ok((
-                Err(err),
-                TraceBuilder::new("empty".to_owned()).finalize())));
+                return Box::new(future::ok(
+                    (Err(err), 
+                    TraceBuilder::new("empty".to_owned()).finalize())));
             },
         };
 
@@ -96,7 +96,7 @@ impl LocustDB {
 
     pub fn ast(&self, query: &str) -> String {
         match parser::parse_query(query) {
-            Ok(query) => format!("{:?}", query),
+            Ok(query) => format!("{:#?}", query),
             Err(err) => format!("{:?}", err),
         }
     }

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -1,425 +1,187 @@
-#![allow(unused_parens)]
+extern crate sqlparser;
 
-use engine::aggregator::Aggregator;
-use engine::query::*;
-use ingest::raw_val::RawVal;
-use nom::{digit, is_alphabetic, is_alphanumeric, multispace};
-use std::boxed::Box;
-use std::str;
-use std::str::FromStr;
+use sqlparser::sqlparser::*;
+use sqlparser::sqlast::*;
+use engine::query::Query;
 use syntax::expression::*;
-use syntax::limit::LimitClause;
-use time;
+use engine::aggregator::*;
+use ingest::raw_val::RawVal;
+use syntax::limit::*;
+use sqlparser::dialect::GenericSqlDialect;
+use QueryError;
 
+// Convert sqlparser-rs `ASTNode` to LocustDB's `Query`
+pub fn parse_query(query: &str) -> Result<Query, QueryError> {
+    let dialect = GenericSqlDialect {};
+    let ast = match Parser::parse_sql(&dialect, query.to_string()) {
+        Ok(ast) => ast,
+        Err(e) => {
+           if let ParserError::ParserError(e_str) = e {
+               return Err(QueryError::ParseError(e_str));
+           }
+           return Err(QueryError::FatalError(format!("{:?}", e)));
+        }
+    };
 
-named!(pub parse_query<&[u8], Query>, alt_complete!(full_query | simple_query));
+    let mut select = Vec::<Expr>::new();
+    let mut aggregate = Vec::<(Aggregator, Expr)>::new();
+    let mut table = String::new();
+    let mut filter = Expr::Const(RawVal::Int(1));
+    let mut order_by_str = None;
+    let mut order_desc = false;
+    let mut limit_clause = LimitClause { limit: 100, offset: 0 };
+    let order_by_index = None;
 
-named!(full_query<&[u8], Query>,
-    do_parse!(
-        opt!(multispace) >>
-        tag_no_case!("select") >>
-        multispace >>
-        select: select_clauses >>
-        opt!(multispace) >>
-        table: from_clause >>
-        multispace >>
-        tag_no_case!("where") >>
-        multispace >>
-        filter: expr >>
-        opt!(multispace) >>
-        order_by: opt!(order_by_clause) >>
-        opt!(multispace) >>
-        limit: opt!(limit_clause) >>
-        opt!(multispace) >>
-        char!(';') >>
-        (construct_query(select, table, filter, order_by, limit))
-    )
-);
+    if let ASTNode::SQLSelect 
+        {projection, relation, selection, order_by, limit, .. } = ast.to_owned() 
+    {
+        for elem in projection {
+            match elem.to_owned() {
+                ASTNode::SQLIdentifier(expr) => 
+                    select.push(Expr::ColName(expr)),
+                ASTNode::SQLValue(constant) => 
+                    select.push(Expr::Const(get_raw_val(constant))),
+                ASTNode::SQLWildcard => 
+                    select.push(Expr::ColName('*'.to_string())),
+                ASTNode::SQLBinaryExpr{left, op, right} => {
+                    select.push(generate_expression(left, op, right)?);
+                },
+                ASTNode::SQLFunction{id, args} => {
+                    let expr = match args[0].to_owned() {
+                        ASTNode::SQLValue(literal) => 
+                            Expr::Const(get_raw_val(literal)),
+                        ASTNode::SQLIdentifier(identifier) => 
+                            Expr::ColName(identifier),
+                        ASTNode::SQLBinaryExpr{left, op, right} => 
+                            generate_expression(left, op, right)?,
+                        _ => Expr::Const(RawVal::Int(1))
+                    };
 
+                    match id.to_uppercase().as_ref() {
+                        "COUNT" => {
+                            aggregate.push((Aggregator::Count, expr));
+                        },
+                        "SUM" => {
+                            aggregate.push((Aggregator::Sum, expr));
+                        },
+                        "TO_YEAR" => {
+                            select.push(Expr::Func1(Func1Type::ToYear, Box::new(expr)));
+                        },
+                        _ => return Err(QueryError::NotImplemented(format!("{:?}", id))),
+                    };
+                },
 
-named!(simple_query<&[u8], Query>,
-    do_parse!(
-        opt!(multispace) >>
-        tag_no_case!("select") >>
-        multispace >>
-        select: select_clauses >>
-        opt!(multispace) >>
-        table: from_clause >>
-        opt!(multispace) >>
-        order_by: opt!(order_by_clause) >>
-        opt!(multispace) >>
-        limit: opt!(limit_clause) >>
-        opt!(multispace) >>
-        opt!(char!(';')) >>
-        (construct_query(select, table, Expr::Const(RawVal::Int(1)), order_by, limit))
-    )
-);
+                _ => return Err(QueryError::NotImplemented(format!("{:?}", elem))),
+            }
+        }
 
-fn construct_query(select_clauses: Vec<AggregateOrSelect>,
-                   table: &str,
-                   filter: Expr,
-                   order_by: Option<(String, bool)>,
-                   limit: Option<LimitClause>)
-                   -> Query {
-    let (select, aggregate) = partition(select_clauses);
-    let order_desc = order_by.as_ref().map(|x| x.1).unwrap_or(false);
-    Query {
+        let sql_identifier = relation.ok_or(QueryError::ParseError(format!("Table name missing.")))?;
+        if let ASTNode::SQLIdentifier(table_name) = *sql_identifier {
+            table = table_name;
+        } else {
+            return Err(QueryError::FatalError(format!("{:?}", *sql_identifier)));
+        }
+
+        filter = match selection {
+            Some(binary_expr) => if let ASTNode::SQLBinaryExpr{left, op, right} = *binary_expr.to_owned() {
+                generate_expression(left, op, right)?
+            } else {
+                return Err(QueryError::FatalError(format!("{:?}", *binary_expr)));
+            },
+            None => Expr::Const(RawVal::Int(1))
+        };
+
+        match order_by {
+            Some(sql_order_by_exprs) => {
+                for sql_order_by_expr in sql_order_by_exprs {
+                    if let ASTNode::SQLIdentifier(identifier) = *sql_order_by_expr.expr {
+                        order_by_str = Some(identifier);
+                    }
+                    order_desc = !sql_order_by_expr.asc;
+                }
+            },
+            None => (),
+        };
+
+        
+        limit_clause = LimitClause {
+            limit: 100,
+            offset: 0,
+        };
+        match limit {
+            Some(sql_limit) => if let ASTNode::SQLValue(literal) = *sql_limit {
+                let lmt = match literal {
+                    Value::Long(int) => int,
+                    _ => 100
+                };
+                limit_clause.limit = lmt as u64;
+            },
+            None => (),
+        }
+    }
+
+    let result = Query {
         select,
-        table: table.to_string(),
+        table,
         filter,
         aggregate,
-        order_by: order_by.map(|x| x.0),
+        order_by: order_by_str,
         order_desc,
-        limit: limit.unwrap_or(LimitClause { limit: 100, offset: 0 }),
-        order_by_index: None,
+        limit: limit_clause,
+        order_by_index,
+    };
+
+    Ok(result)
+}
+
+/// Fn to convert `SQLBinaryExpr` to LocustDB's `Expr`.
+fn generate_expression(l: Box<ASTNode>, o: SQLOperator, r: Box<ASTNode>) 
+    -> Result<Expr, QueryError> 
+{
+    let operator = match o {
+        SQLOperator::And => Func2Type::And,
+        SQLOperator::Plus => Func2Type::Add,
+        SQLOperator::Minus => Func2Type::Subtract,
+        SQLOperator::Multiply => Func2Type::Multiply,
+        SQLOperator::Divide => Func2Type::Divide,
+        SQLOperator::Gt => Func2Type::GT,
+        SQLOperator::Lt => Func2Type::LT,
+        SQLOperator::Eq => Func2Type::Equals,
+        SQLOperator::NotEq => Func2Type::NotEquals,
+        SQLOperator::Or => Func2Type::Or,
+        _ => return Err(QueryError::NotImplemented(format!("Operator {:?}", o))),
+    };
+
+    let lhs = match *l.to_owned() {
+        ASTNode::SQLValue(literal) => Box::new(Expr::Const(get_raw_val(literal))),
+        ASTNode::SQLIdentifier(identifier) => Box::new(Expr::ColName(identifier)),
+        // Recursively call in case of multiple operator expression
+        ASTNode::SQLBinaryExpr{left, op, right} => Box::new(generate_expression(left, op, right)?),
+        _ => return Err(QueryError::NotImplemented(format!("{:?}", *l)))
+    };
+
+    let rhs = match *r.to_owned() {
+        ASTNode::SQLValue(literal) => Box::new(Expr::Const(get_raw_val(literal))),
+        ASTNode::SQLIdentifier(identifier) => Box::new(Expr::ColName(identifier)),
+        // Recursively call in case of multiple operator expression        
+        ASTNode::SQLBinaryExpr{left, op, right} => Box::new(generate_expression(left, op, right)?),
+        _ => return Err(QueryError::NotImplemented(format!("{:?}", *r)))
+    };
+
+    Ok(Expr::Func2(operator, lhs, rhs))
+}
+
+// Fn to map sqlparser-rs `Value` to LocustDB's `RawVal`.
+fn get_raw_val(constant: Value) -> RawVal {
+    match constant.to_owned() {
+        Value::Long(int) => RawVal::Int(int),
+        Value::String(string)
+        | Value::SingleQuotedString(string) 
+        | Value::DoubleQuotedString(string) => RawVal::Str(string),
+        Value::Null => RawVal::Null,
+        _ => RawVal::Null
     }
 }
-
-fn partition(select_or_aggregates: Vec<AggregateOrSelect>)
-             -> (Vec<Expr>, Vec<(Aggregator, Expr)>) {
-    let (selects, aggregates): (Vec<AggregateOrSelect>, Vec<AggregateOrSelect>) =
-        select_or_aggregates.into_iter()
-            .partition(|x| match *x {
-                AggregateOrSelect::Select(_) => true,
-                _ => false,
-            });
-
-    (selects.into_iter()
-         .filter_map(|x| match x {
-             AggregateOrSelect::Select(expr) => Some(expr),
-             _ => None,
-         })
-         .collect(),
-     aggregates.into_iter()
-         .filter_map(|x| match x {
-             AggregateOrSelect::Aggregate(agg) => Some(agg),
-             _ => None,
-         })
-         .collect())
-}
-
-named!(from_clause<&[u8], &str>,
-    do_parse!(
-        tag_no_case!("from") >>
-        multispace >>
-        from: identifier >>
-        (from)
-    )
-);
-
-named!(select_clauses<&[u8], Vec<AggregateOrSelect>>,
-    alt!(
-        do_parse!(
-            opt!(multispace) >>
-            tag!("*") >>
-            opt!(multispace) >>
-            (vec![AggregateOrSelect::Select(Expr::ColName("*".to_string()))])
-        ) |
-        separated_list!(
-            tag!(","),
-            alt_complete!(aggregate_clause | select_clause)
-        )
-    )
-);
-
-named!(aggregate_clause<&[u8], AggregateOrSelect>,
-    do_parse!(
-        opt!(multispace) >>
-        atype: aggregate_func >>
-        char!('(') >>
-        e: expr >>
-        opt!(multispace) >>
-        char!(')') >>
-        (AggregateOrSelect::Aggregate((atype, e)))
-    )
-);
-
-named!(select_clause<&[u8], AggregateOrSelect>, map!(expr, AggregateOrSelect::Select));
-
-named!(aggregate_func<&[u8], Aggregator>, alt!(count | sum));
-
-named!(count<&[u8], Aggregator>,
-    map!( tag_no_case!("count"), |_| Aggregator::Count )
-);
-
-named!(sum<&[u8], Aggregator>,
-    map!( tag_no_case!("sum"), |_| Aggregator::Sum )
-);
-
-named!(expr<&[u8], Expr>,
-    do_parse!(
-        opt!(multispace) >>
-        result: alt!(infix_expr | expr_no_left_recur) >>
-        (result)
-    )
-);
-
-named!(expr_no_left_recur<&[u8], Expr>,
-    do_parse!(
-        opt!(multispace) >>
-        result: alt!(parentheses | template | function | to_year | negation | colname | constant) >>
-        (result)
-    )
-);
-
-named!(parentheses<&[u8], Expr>,
-    do_parse!(
-        char!('(') >>
-        e1: expr >>
-        opt!(multispace) >>
-        char!(')') >>
-        (e1)
-    )
-);
-
-named!(template<&[u8], Expr>,
-    alt!( last_hour | last_day )
-);
-
-named!(last_hour<&[u8], Expr>,
-    map!(
-        tag_no_case!("$LAST_HOUR"),
-        |_| Expr::Func2(
-                Func2Type::GT,
-                Box::new(Expr::ColName("timestamp".to_string())),
-                Box::new(Expr::Const(RawVal::Int(time::now().to_timespec().sec - 3600)))
-        )
-    )
-);
-
-named!(last_day<&[u8], Expr>,
-    map!(
-        tag_no_case!("$LAST_DAY"),
-        |_| Expr::Func2(
-                Func2Type::GT,
-                Box::new(Expr::ColName("timestamp".to_string())),
-                Box::new(Expr::Const(RawVal::Int(time::now().to_timespec().sec - 86400)))
-        )
-    )
-);
-
-named!(function<&[u8], Expr>,
-    do_parse!(
-        ft: function_name >>
-        char!('(') >>
-        e1: expr >>
-        opt!(multispace) >>
-        char!(',') >>
-        e2: expr >>
-        opt!(multispace) >>
-        char!(')') >>
-        (Expr::func(ft, e1, e2))
-    )
-);
-
-named!(infix_expr<&[u8], Expr>,
-    do_parse!(
-        e1: expr_no_left_recur >>
-        opt!(multispace) >>
-        ft: infix_function_name >>
-        e2: expr >>
-        (Expr::func(ft, e1, e2))
-    )
-);
-
-named!(negation<&[u8], Expr>,
-    do_parse!(
-        char!('-') >>
-        opt!(multispace) >>
-        e: expr >>
-        (Expr::func1(Func1Type::Negate, e))
-    )
-);
-
-named!(to_year<&[u8], Expr>,
-    do_parse!(
-        tag!("to_year") >>
-        opt!(multispace) >>
-        char!('(') >>
-        opt!(multispace) >>
-        e: expr >>
-        opt!(multispace) >>
-        char!(')') >>
-        (Expr::func1(Func1Type::ToYear, e))
-    )
-);
-
-named!(constant<&[u8], Expr>,
-    map!(
-        alt!(integer |  string),
-        Expr::Const
-    )
-);
-
-
-named!(integer<&[u8], RawVal>,
-    map!(
-        map_res!(
-            map_res!(
-                digit,
-                str::from_utf8
-            ),
-            FromStr::from_str
-        ),
-        RawVal::Int
-    )
-);
-
-named!(number<&[u8], u64>,
-    map_res!(
-        map_res!(
-            digit,
-            str::from_utf8
-        ),
-        FromStr::from_str
-    )
-);
-
-named!(string<&[u8], RawVal>,
-    alt!(
-        do_parse!(
-            char!('"') >>
-            s: is_not!("\"") >>
-            char!('"') >>
-            (RawVal::Str(str::from_utf8(s).unwrap().to_string()))
-        ) |
-        do_parse!(
-            tag!("\"\"") >>
-            (RawVal::Str("".to_string()))
-        )
-    )
-);
-
-named!(colname<&[u8], Expr>,
-    map!(
-        identifier,
-        |ident: &str| Expr::ColName(ident.to_string())
-    )
-);
-
-named!(function_name<&[u8], Func2Type>,
-    alt!( infix_function_name | regex )
-);
-
-named!(infix_function_name<&[u8], Func2Type>,
-    alt!( equals | not_equals | and | or | greater | less | add | subtract | divide | multiply )
-);
-
-named!(divide<&[u8], Func2Type>,
-    map!( tag!("/"), |_| Func2Type::Divide)
-);
-
-named!(add<&[u8], Func2Type>,
-    map!( tag!("+"), |_| Func2Type::Add)
-);
-
-named!(multiply<&[u8], Func2Type>,
-    map!( tag!("*"), |_| Func2Type::Multiply)
-);
-
-named!(subtract<&[u8], Func2Type>,
-    map!( tag!("-"), |_| Func2Type::Subtract)
-);
-
-named!(equals<&[u8], Func2Type>,
-    map!( tag!("="), |_| Func2Type::Equals)
-);
-
-named!(not_equals<&[u8], Func2Type>,
-    map!( tag!("<>"), |_| Func2Type::NotEquals)
-);
-
-named!(greater<&[u8], Func2Type>,
-    map!( tag!(">"), |_| Func2Type::GT)
-);
-
-named!(less<&[u8], Func2Type>,
-    map!( tag!("<"), |_| Func2Type::LT)
-);
-
-named!(and<&[u8], Func2Type>,
-    map!( tag_no_case!("and"), |_| Func2Type::And)
-);
-
-named!(or<&[u8], Func2Type>,
-    map!( tag_no_case!("or"), |_| Func2Type::Or)
-);
-
-named!(regex<&[u8], Func2Type>,
-    map!( tag_no_case!("regex"), |_| Func2Type::RegexMatch)
-);
-
-
-named!(identifier<&[u8], &str>,
-    map_res!(
-        take_while1!(is_ident_char),
-        create_sql_identifier
-    )
-);
-
-fn create_sql_identifier(bytes: &[u8]) -> Result<&str, String> {
-    if is_ident_start_char(bytes[0]) {
-        str::from_utf8(bytes).map_err(|_| "UTF8Error".to_string())
-    } else {
-        Err("Identifier must not start with number.".to_string())
-    }
-}
-
-fn is_ident_start_char(chr: u8) -> bool {
-    is_alphabetic(chr) || chr == b'_'
-}
-
-fn is_ident_char(chr: u8) -> bool {
-    is_alphanumeric(chr) || chr == b'_'
-}
-
-named!(limit_clause<&[u8], LimitClause>,
-    do_parse!(
-        tag_no_case!("limit") >>
-        multispace >>
-        limit_val: number >>
-        offset_val: opt!(
-            do_parse!(
-                multispace >>
-                tag_no_case!("offset") >>
-                multispace >>
-                val: number >>
-                (val)
-            )) >>
-        (LimitClause{limit: limit_val,
-                     offset: match offset_val {
-                                 Some(inner) => inner,
-                                 None => 0,
-                             }
-                    })
-    )
-);
-
-named!(order_by_clause<&[u8], (String, bool)>,
-    alt!(
-        do_parse!(
-            tag_no_case!("order by") >>
-            multispace >>
-            order_by: identifier >>
-            multispace >>
-            tag_no_case!("desc") >>
-            (order_by.to_string(), true)
-        ) |
-        do_parse!(
-            tag_no_case!("order by") >>
-            multispace >>
-            order_by: identifier >>
-            opt!(preceded!(multispace, tag_no_case!("asc"))) >>
-            (order_by.to_string(), false)
-        )
-    )
-);
-
-enum AggregateOrSelect {
-    Aggregate((Aggregator, Expr)),
-    Select(Expr),
-}
-
 
 #[cfg(test)]
 mod tests {
@@ -428,22 +190,23 @@ mod tests {
     #[test]
     fn test_select_star() {
         assert_eq!(
-            format!("{:?}", parse_query("select * from default;".as_bytes())),
-            "Done([], Query { select: [ColName(\"*\")], table: \"default\", filter: Const(Int(1)), aggregate: [], order_by: None, order_desc: false, limit: LimitClause { limit: 100, offset: 0 }, order_by_index: None })");
+            format!("{:?}", parse_query("select * from default")),
+            "Ok(Query { select: [ColName(\"*\")], table: \"default\", filter: Const(Int(1)), aggregate: [], order_by: None, order_desc: false, limit: LimitClause { limit: 100, offset: 0 }, order_by_index: None })");
     }
 
-    #[test]
-    fn test_last_hour() {
-        assert!(
-            format!("{:?}", parse_query("select * from default where $LAST_HOUR;".as_bytes())).starts_with(
-                "Done([], Query { select: [ColName(\"*\")], table: \"default\", filter: Func2(GT, ColName(\"timestamp\"), Const(Int(")
-        )
-    }
+    // TODO: Add $LAST_HOUR, $LAST_DAY support
+    // #[test]
+    // fn test_last_hour() {
+    //     assert!(
+    //         format!("{:?}", parse_query("select * from default where $LAST_HOUR")).starts_with(
+    //             "Ok(Query { select: [ColName(\"*\")], table: \"default\", filter: Func2(GT, ColName(\"timestamp\"), Const(Int(")
+    //     )
+    // }
 
     #[test]
     fn test_to_year() {
         assert_eq!(
-            format!("{:?}", parse_query("select to_year(ts) from default;".as_bytes())),
-            "Done([], Query { select: [Func1(ToYear, ColName(\"ts\"))], table: \"default\", filter: Const(Int(1)), aggregate: [], order_by: None, order_desc: false, limit: LimitClause { limit: 100, offset: 0 }, order_by_index: None })");
+            format!("{:?}", parse_query("select to_year(ts) from default")),
+            "Ok(Query { select: [Func1(ToYear, ColName(\"ts\"))], table: \"default\", filter: Const(Int(1)), aggregate: [], order_by: None, order_desc: false, limit: LimitClause { limit: 100, offset: 0 }, order_by_index: None })");
     }
 }


### PR DESCRIPTION
#4 
Used [sqlparser-rs](https://github.com/andygrove/sqlparser-rs)
I had to make some changes in the original sqlparser-rs so I pushed those changes to its [fork](https://github.com/virattara/sqlparser-rs) and have added that fork as a dependency in cargo.toml rather than using the published crate.
I would like to know how you want this to go.
I suggest including sqlparser-rs inside LocustDB's syntax directory.

Also, I haven't added `$LAST_HOUR` and `$LAST_DAY` fns yet. Ideally these should go inside the parser module.