### PR TITLE
Support non-dictionary encoded string columns in group by

### DIFF
--- a/src/engine/byte_slices.rs
+++ b/src/engine/byte_slices.rs
@@ -1,0 +1,109 @@
+use std::cmp::min;
+use std::fmt::Write;
+use std::fmt;
+
+use hex;
+use itertools::Itertools;
+
+use engine::typed_vec::*;
+use engine::types::*;
+use ingest::raw_val::RawVal;
+
+
+#[derive(HeapSizeOf, Debug)]
+pub struct ByteSlices<'a> {
+    pub row_len: usize,
+    pub data: Vec<&'a [u8]>,
+}
+
+impl<'a> ByteSlices<'a> {
+    pub fn new(row_len: usize) -> ByteSlices<'a> {
+        ByteSlices { row_len, data: Vec::default() }
+    }
+
+    pub fn with_capacity(row_len: usize, rows: usize) -> ByteSlices<'a> {
+        ByteSlices { row_len, data: Vec::with_capacity(row_len * rows) }
+    }
+
+    pub fn row(&self, i: usize) -> &[&'a [u8]] {
+        &self.data[i * self.row_len..(i + 1) * self.row_len]
+    }
+}
+
+impl<'a> AnyVec<'a> for ByteSlices<'a> {
+    fn len(&self) -> usize { self.data.len() / self.row_len }
+    fn get_raw(&self, _i: usize) -> RawVal { panic!(self.type_error("get_raw")) }
+    fn get_type(&self) -> EncodingType { EncodingType::ByteSlices(self.row_len) }
+
+    fn sort_indices_desc(&self, indices: &mut Vec<usize>) {
+        indices.sort_unstable_by(|i, j| self.row(*i).cmp(&self.row(*j)).reverse());
+    }
+
+    fn sort_indices_asc(&self, indices: &mut Vec<usize>) {
+        indices.sort_unstable_by_key(|i| self.row(*i));
+    }
+
+    fn append_all(&mut self, _other: &AnyVec<'a>, _count: usize) -> Option<BoxedVec<'a>> {
+        panic!(self.type_error("append_all"))
+    }
+
+    fn slice_box<'b>(&'b self, _from: usize, _to: usize) -> BoxedVec<'b> where 'a: 'b {
+        panic!(self.type_error("slice_box"))
+        // let to = min(to, self.len());
+        // Box::new(&self[self.row_len * from..self.row_len * to])
+    }
+
+    fn type_error(&self, func_name: &str) -> String { format!("RawByteSlices.{}", func_name) }
+
+    fn display(&self) -> String {
+        format!("ByteSlices[{}]{}", self.row_len, display_byte_slices(&self.data, 120))
+    }
+
+    fn cast_ref_byte_slices(&self) -> &ByteSlices<'a> { self }
+    fn cast_ref_mut_byte_slices(&mut self) -> &mut ByteSlices<'a> { self }
+}
+
+pub fn display_byte_slices(slice: &[&[u8]], max_chars: usize) -> String {
+    let mut length = slice.len();
+    loop {
+        let result = _display_slice(slice, length);
+        if result.len() < max_chars { break; }
+        length = min(length - 1, max_chars * length / result.len());
+        if length < 3 {
+            return _display_slice(slice, 2);
+        }
+    }
+    if length == slice.len() {
+        return _display_slice(slice, slice.len());
+    }
+    for l in length..max_chars {
+        if _display_slice(slice, l).len() > max_chars {
+            return _display_slice(slice, l - 1);
+        }
+    }
+    "display_slice error!".to_owned()
+}
+
+fn _display_slice(slice: &[&[u8]], max: usize) -> String {
+    let mut result = String::new();
+    write!(result, "[").unwrap();
+    write!(result,
+           "{}",
+           slice[..max]
+               .iter()
+               .map(|x| format!("0x{}", hex::encode(x)))
+               .join(", ")
+    ).unwrap();
+    if max < slice.len() {
+        write!(result, ", ...] ({} more)", slice.len() - max).unwrap();
+    } else {
+        write!(result, "]").unwrap();
+    }
+    result
+}
+
+impl<'a> fmt::Display for ByteSlices<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", display_byte_slices(&self.data, 120))
+    }
+}

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -7,6 +7,7 @@ pub mod query;
 pub mod query_task;
 pub mod typed_vec;
 pub mod types;
+pub mod byte_slices;
 
 
 pub use self::typed_vec::{
@@ -21,3 +22,4 @@ pub use self::typed_vec::{
 pub use self::filter::Filter;
 pub use self::vector_op::*;
 pub use self::types::*;
+pub use self::byte_slices::*;

--- a/src/engine/query.rs
+++ b/src/engine/query.rs
@@ -8,6 +8,7 @@ use engine::*;
 use engine::aggregator::*;
 use engine::batch_merging::*;
 use engine::query_plan::QueryPlan;
+use engine::query_plan;
 use engine::types::EncodingType;
 use engine::types::Type;
 use ingest::raw_val::RawVal;
@@ -124,7 +125,7 @@ impl Query {
         let ((grouping_key_plan, raw_grouping_key_type),
             max_grouping_key,
             decode_plans) =
-            QueryPlan::compile_grouping_key(&self.select, filter, columns)?;
+            query_plan::compile_grouping_key(&self.select, filter, columns)?;
         let raw_grouping_key = query_plan::prepare(grouping_key_plan, &mut executor);
 
         // Reduce cardinality of grouping key if necessary and perform grouping

--- a/src/engine/typed_vec.rs
+++ b/src/engine/typed_vec.rs
@@ -13,6 +13,7 @@ use heapsize::HeapSizeOf;
 use ingest::raw_val::RawVal;
 use itertools::Itertools;
 use mem_store::value::Val;
+use engine::ByteSlices;
 
 
 pub type BoxedVec<'a> = Box<AnyVec<'a> + 'a>;
@@ -39,6 +40,7 @@ pub trait AnyVec<'a>: Send + Sync {
     fn cast_ref_premerge(&self) -> &[Premerge] { panic!(self.type_error("cast_ref_merge_op")) }
     fn cast_str_const(&self) -> string::String { panic!(self.type_error("cast_str_const")) }
     fn cast_i64_const(&self) -> i64 { panic!(self.type_error("cast_i64_const")) }
+    fn cast_ref_byte_slices(&self) -> &ByteSlices<'a> { panic!(self.type_error("cast_ref_byte_slices")) }
 
     fn cast_ref_mut_str(&mut self) -> &mut Vec<&'a str> { panic!(self.type_error("cast_ref_mut_str")) }
     fn cast_ref_mut_usize(&mut self) -> &mut Vec<usize> { panic!(self.type_error("cast_ref_mut_usize")) }
@@ -48,8 +50,9 @@ pub trait AnyVec<'a>: Send + Sync {
     fn cast_ref_mut_u16(&mut self) -> &mut Vec<u16> { panic!(self.type_error("cast_ref_mut_u16")) }
     fn cast_ref_mut_u8(&mut self) -> &mut Vec<u8> { panic!(self.type_error("cast_ref_mut_u8")) }
     fn cast_ref_mut_mixed(&mut self) -> &mut Vec<Val<'a>> { panic!(self.type_error("cast_ref_mut_mixed")) }
-    fn cast_ref_mut_merge_op(&mut self) -> &mut Vec<MergeOp> { panic!(self.type_error("cast_ref_merge_op")) }
-    fn cast_ref_mut_premerge(&mut self) -> &mut Vec<Premerge> { panic!(self.type_error("cast_ref_merge_op")) }
+    fn cast_ref_mut_merge_op(&mut self) -> &mut Vec<MergeOp> { panic!(self.type_error("cast_ref_mut_merge_op")) }
+    fn cast_ref_mut_premerge(&mut self) -> &mut Vec<Premerge> { panic!(self.type_error("cast_ref_mut_premerge_op")) }
+    fn cast_ref_mut_byte_slices(&mut self) -> &mut ByteSlices<'a> { panic!(self.type_error("cast_ref_mut_byte_slices")) }
 
     fn to_mixed(&self) -> Vec<Val<'a>> { panic!(self.type_error("to_mixed")) }
 
@@ -368,7 +371,25 @@ impl<'c> GenericVec<Val<'c>> for Val<'c> {
 
     fn t() -> EncodingType { EncodingType::Val }
 }
+/*
+impl<'c> GenericVec<&'c str> for ByteSlices<'c> {
+    fn unwrap<'a, 'b>(vec: &'b AnyVec<'a>) -> &'b [ByteSlices<'c>] where ByteSlices<'c>: 'a {
+        unsafe {
+            mem::transmute::<_, &'b [ByteSlices<'c>]>(vec.cast_ref_str())
+        }
+    }
 
+    fn unwrap_mut<'a, 'b>(vec: &'b mut AnyVec<'a>) -> &'b mut Vec<ByteSlices<'c>> where ByteSlices<'c>: 'a {
+        unsafe {
+            mem::transmute::<_, &'b mut Vec<ByteSlices<'c>>>(vec.cast_ref_mut_str())
+        }
+    }
+
+    fn wrap_one(value: &'c str) -> RawVal { RawVal::Str(value.to_string()) }
+
+    fn t() -> EncodingType { EncodingType::Str }
+}
+*/
 
 pub trait GenericIntVec<T>: GenericVec<T> + CastUsize + PrimInt + Hash + 'static {}
 
@@ -450,7 +471,7 @@ impl GenericVec<Premerge> for Premerge {
 }
 
 
-fn display_slice<T: Display>(slice: &[T], max_chars: usize) -> String {
+pub fn display_slice<T: Display>(slice: &[T], max_chars: usize) -> String {
     let mut length = slice.len();
     loop {
         let result = _display_slice(slice, length);

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -15,6 +15,7 @@ pub enum EncodingType {
     U32,
     U64,
 
+    ByteSlices(usize),
     Premerge,
     MergeOp,
 }

--- a/src/engine/vector_op/executor.rs
+++ b/src/engine/vector_op/executor.rs
@@ -13,6 +13,7 @@ pub struct QueryExecutor<'a> {
     encoded_group_by: Option<BufferRef>,
     count: usize,
     last_buffer: BufferRef,
+    shared_buffers: HashMap<&'static str, BufferRef>,
 }
 
 #[derive(Default, Clone)]
@@ -28,6 +29,16 @@ impl<'a> QueryExecutor<'a> {
         self.count += 1;
         self.last_buffer = buffer;
         buffer
+    }
+
+    pub fn shared_buffer(&mut self, name: &'static str) -> BufferRef {
+        if self.shared_buffers.get(name).is_none() {
+            let buffer = BufferRef(self.count, name);
+            self.count += 1;
+            self.last_buffer = buffer;
+            self.shared_buffers.insert(name, buffer);
+        }
+        self.shared_buffers[name]
     }
 
     pub fn last_buffer(&self) -> BufferRef { self.last_buffer }
@@ -282,6 +293,7 @@ impl<'a> Default for QueryExecutor<'a> {
             encoded_group_by: None,
             count: 0,
             last_buffer: BufferRef(0xdead_beef, "ERROR"),
+            shared_buffers: HashMap::default(),
         }
     }
 }

--- a/src/engine/vector_op/hashmap_grouping_byte_slices.rs
+++ b/src/engine/vector_op/hashmap_grouping_byte_slices.rs
@@ -1,0 +1,74 @@
+use fnv::FnvHashMap;
+
+use engine::typed_vec::AnyVec;
+use engine::vector_op::*;
+use engine::*;
+use ingest::raw_val::RawVal;
+
+
+#[derive(Debug)]
+pub struct HashMapGroupingByteSlices {
+    input: BufferRef,
+    unique_out: BufferRef,
+    grouping_key_out: BufferRef,
+    cardinality_out: BufferRef,
+    columns: usize,
+}
+
+impl<'a> HashMapGroupingByteSlices {
+    pub fn boxed(input: BufferRef,
+                 unique_out: BufferRef,
+                 grouping_key_out: BufferRef,
+                 cardinality_out: BufferRef,
+                 columns: usize) -> BoxedOperator<'a> {
+        Box::new(HashMapGroupingByteSlices {
+            input,
+            unique_out,
+            grouping_key_out,
+            cardinality_out,
+            columns,
+        })
+    }
+}
+
+impl<'a> VecOperator<'a> for HashMapGroupingByteSlices {
+    fn execute(&mut self, stream: bool, scratchpad: &mut Scratchpad<'a>) {
+        // TODO(clemens): Fnv is suboptimal for larger inputs (http://cglab.ca/~abeinges/blah/hash-rs/). use xx hash?
+        let count = {
+            let raw_grouping_key_any = scratchpad.get_any(self.input);
+            let raw_grouping_key = raw_grouping_key_any.cast_ref_byte_slices();
+            let mut map: FnvHashMap<&[&'a [u8]], u32> = FnvHashMap::default();
+            let mut grouping = scratchpad.get_mut::<u32>(self.grouping_key_out);
+            let mut unique_any = scratchpad.get_any_mut(self.unique_out);
+            let mut unique = unique_any.cast_ref_mut_byte_slices();
+            if stream { grouping.clear() }
+            for row in raw_grouping_key.data.chunks(raw_grouping_key.row_len) {
+                grouping.push(*map.entry(row).or_insert_with(|| {
+                    for slice in row {
+                        unique.data.push(*slice);
+                    }
+                    unique.len() as u32 - 1
+                }));
+            }
+            RawVal::Int(unique.len() as i64)
+        };
+        scratchpad.set(self.cardinality_out, AnyVec::constant(count));
+    }
+
+    fn init(&mut self, _: usize, batch_size: usize, scratchpad: &mut Scratchpad<'a>) {
+        // TODO(clemens): Estimate capacities for unique + map?
+        scratchpad.set(self.unique_out, Box::new(ByteSlices::new(self.columns)));
+        scratchpad.set(self.grouping_key_out, AnyVec::owned(Vec::<u32>::with_capacity(batch_size)));
+    }
+
+    fn inputs(&self) -> Vec<BufferRef> { vec![self.input] }
+    fn outputs(&self) -> Vec<BufferRef> { vec![self.unique_out, self.grouping_key_out, self.cardinality_out] }
+    fn can_stream_input(&self, _: BufferRef) -> bool { false }
+    fn can_stream_output(&self, output: BufferRef) -> bool { output != self.unique_out }
+    fn allocates(&self) -> bool { true }
+
+    fn display_op(&self, _: bool) -> String {
+        format!("hashmap_grouping({})", self.input)
+    }
+}
+

--- a/src/engine/vector_op/mod.rs
+++ b/src/engine/vector_op/mod.rs
@@ -17,6 +17,7 @@ mod encode_const;
 mod exists;
 mod filter;
 mod hashmap_grouping;
+mod hashmap_grouping_byte_slices;
 mod merge;
 mod merge_aggregate;
 mod merge_deduplicate;
@@ -39,6 +40,8 @@ mod lz4_decode;
 pub mod merge_deduplicate_partitioned;
 pub mod partition;
 pub mod subpartition;
+pub mod slice_pack;
+pub mod slice_unpack;
 
 pub use self::vector_operator::*;
 pub use self::executor::QueryExecutor;

--- a/src/engine/vector_op/slice_pack.rs
+++ b/src/engine/vector_op/slice_pack.rs
@@ -1,0 +1,41 @@
+use engine::*;
+use engine::vector_op::vector_operator::*;
+
+
+#[derive(Debug)]
+pub struct SlicePackString {
+    pub input: BufferRef,
+    pub output: BufferRef,
+    pub stride: usize,
+    pub offset: usize,
+}
+
+impl<'a> VecOperator<'a> for SlicePackString {
+    fn execute(&mut self, _: bool, scratchpad: &mut Scratchpad<'a>) {
+        let data = scratchpad.get::<&'a str>(self.input);
+        let mut packed_any = scratchpad.get_any_mut(self.output);
+        let packed = packed_any.cast_ref_mut_byte_slices();
+        for (i, datum) in data.iter().enumerate() {
+            packed.data[i * self.stride + self.offset] = datum.as_bytes();
+        }
+    }
+
+    fn init(&mut self, _: usize, batch_size: usize, scratchpad: &mut Scratchpad<'a>) {
+        if scratchpad.get_any(self.output).len() == 0 {
+            scratchpad.set(self.output, Box::new(ByteSlices {
+                row_len: self.stride,
+                data: vec![&[]; batch_size * self.stride],
+            }));
+        }
+    }
+
+    fn inputs(&self) -> Vec<BufferRef> { vec![self.input] }
+    fn outputs(&self) -> Vec<BufferRef> { vec![self.output] }
+    fn can_stream_input(&self, _: BufferRef) -> bool { true }
+    fn can_stream_output(&self, _: BufferRef) -> bool { true }
+    fn allocates(&self) -> bool { true }
+
+    fn display_op(&self, _: bool) -> String {
+        format!("{}[{}, {}, ...] = {}", self.output, self.offset, self.offset + self.stride, self.input)
+    }
+}

--- a/src/engine/vector_op/slice_unpack.rs
+++ b/src/engine/vector_op/slice_unpack.rs
@@ -1,0 +1,38 @@
+use std::str;
+
+use engine::vector_op::vector_operator::*;
+
+
+#[derive(Debug)]
+pub struct SliceUnpackString {
+    pub input: BufferRef,
+    pub output: BufferRef,
+    pub stride: usize,
+    pub offset: usize,
+}
+
+impl<'a> VecOperator<'a> for SliceUnpackString {
+    fn execute(&mut self, _: bool, scratchpad: &mut Scratchpad<'a>) {
+        let packed_any = scratchpad.get_any(self.input);
+        let packed = packed_any.cast_ref_byte_slices();
+        let mut unpacked = scratchpad.get_mut::<&'a str>(self.output);
+        for datum in packed.data.iter().skip(self.offset).step_by(self.stride) {
+            unpacked.push(unsafe { str::from_utf8_unchecked(datum) });
+        }
+    }
+
+    fn init(&mut self, _: usize, batch_size: usize, scratchpad: &mut Scratchpad<'a>) {
+        scratchpad.set(self.output, Box::new(Vec::<&'a str>::with_capacity(batch_size)));
+    }
+
+    fn inputs(&self) -> Vec<BufferRef> { vec![self.input] }
+    fn outputs(&self) -> Vec<BufferRef> { vec![self.output] }
+    fn can_stream_input(&self, _: BufferRef) -> bool { true }
+    fn can_stream_output(&self, _: BufferRef) -> bool { true }
+    fn allocates(&self) -> bool { true }
+
+    fn display_op(&self, _: bool) -> String {
+        format!("{}[{}, {}, ...] = {}", self.output, self.offset, self.offset + self.stride, self.input)
+    }
+    fn display_output(&self) -> bool { false }
+}

--- a/src/engine/vector_op/unpack_strings.rs
+++ b/src/engine/vector_op/unpack_strings.rs
@@ -15,7 +15,7 @@ pub struct UnpackStrings<'a> {
 impl<'a> VecOperator<'a> for UnpackStrings<'a> {
     fn execute(&mut self, streaming: bool, scratchpad: &mut Scratchpad<'a>) {
         let mut decoded = scratchpad.get_mut::<&'a str>(self.unpacked);
-        if streaming { decoded.clear() }
+        if streaming { panic!("Not supported") }
         for elem in self.iterator.as_mut().unwrap() {
             decoded.push(elem);
             if decoded.capacity() == decoded.len() { return; }
@@ -38,7 +38,7 @@ impl<'a> VecOperator<'a> for UnpackStrings<'a> {
     fn inputs(&self) -> Vec<BufferRef> { vec![self.packed] }
     fn outputs(&self) -> Vec<BufferRef> { vec![self.unpacked] }
     fn can_stream_input(&self, _: BufferRef) -> bool { false }
-    fn can_stream_output(&self, _: BufferRef) -> bool { true }
+    fn can_stream_output(&self, _: BufferRef) -> bool { false }
     fn allocates(&self) -> bool { true }
     fn is_streaming_producer(&self) -> bool { true }
     fn has_more(&self) -> bool { self.has_more }

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -380,21 +380,40 @@ fn test_group_by_string() {
         locustdb::colgen::GenTable {
             name: "test".to_string(),
             partitions: 3,
-            partition_size: 4196,
+            partition_size: 4096 + 100,
             columns: vec![
                 ("hex".to_string(),
                  locustdb::colgen::random_hex_string(8)),
                 ("scrambled".to_string(),
-                 locustdb::colgen::random_string(2, 16))
+                 locustdb::colgen::random_string(2, 4)),
             ],
         }
     ));
+
     let query = "SELECT scrambled, count(1) FROM test LIMIT 3;";
     let result = block_on(locustdb.run_query(query, true, vec![])).unwrap().0.unwrap();
     let expected_rows = vec![
-        [Str("006j267n".to_string()), Int(1)],
-        [Str("00w".to_string()), Int(1)],
-        [Str("0198E".to_string()), Int(1)],
+        [Str("00".to_string()), Int(2)],
+        [Str("008V".to_string()), Int(1)],
+        [Str("00dz".to_string()), Int(1)],
+    ];
+    assert_eq!(result.rows, expected_rows);
+
+    let query = "SELECT scrambled, scrambled, count(1) FROM test LIMIT 3;";
+    let result = block_on(locustdb.run_query(query, true, vec![])).unwrap().0.unwrap();
+    let expected_rows = vec![
+        [Str("00".to_string()), Str("00".to_string()), Int(2)],
+        [Str("008V".to_string()), Str("008V".to_string()), Int(1)],
+        [Str("00dz".to_string()), Str("00dz".to_string()), Int(1)],
+    ];
+    assert_eq!(result.rows, expected_rows);
+
+    let query = "SELECT scrambled, hex, count(1) FROM test LIMIT 3;";
+    let result = block_on(locustdb.run_query(query, true, vec![])).unwrap().0.unwrap();
+    let expected_rows = vec![
+        [Str("00".to_string()), Str("b0c836e5fbef7d51".to_string()), Int(1)],
+        [Str("00".to_string()), Str("ffcabba4d5975ef9".to_string()), Int(1)],
+        [Str("008V".to_string()), Str("36027c032adaf264".to_string()), Int(1)],
     ];
     assert_eq!(result.rows, expected_rows);
 }


### PR DESCRIPTION
This implements a new `ByteSlices` data type which represents type agnostic rows made up of references to byte slices. This forms the basis of new query plan functionality that collects multiple string columns present in a group by clause, and allows them to be passed through hashmap grouping and sorting stages.

Supporting group by clauses that have both non-dictionary encoded string columns and integer columns will need another small addition that allows integer columns to be referenced as byte slices.