### PR TITLE
Support simultaneous string, integer group by

### DIFF
--- a/src/engine/typed_vec.rs
+++ b/src/engine/typed_vec.rs
@@ -5,8 +5,10 @@ use std::hash::Hash;
 use std::i64;
 use std::mem;
 use std::string;
+use std::io::Cursor;
 
 use num::PrimInt;
+use byteorder::{NativeEndian, ReadBytesExt};
 
 use engine::types::*;
 use heapsize::HeapSizeOf;
@@ -391,9 +393,9 @@ impl<'c> GenericVec<&'c str> for ByteSlices<'c> {
 }
 */
 
-pub trait GenericIntVec<T>: GenericVec<T> + CastUsize + PrimInt + Hash + 'static {}
+pub trait GenericIntVec<T>: GenericVec<T> + CastUsize + FromBytes<T> + PrimInt + Hash + 'static {}
 
-impl<T> GenericIntVec<T> for T where T: GenericVec<T> + CastUsize + PrimInt + Copy + Hash + 'static {}
+impl<T> GenericIntVec<T> for T where T: GenericVec<T> + CastUsize + FromBytes<T> + PrimInt + Copy + Hash + 'static {}
 
 pub trait ConstType<T>: Clone {
     fn unwrap(vec: &AnyVec) -> T;
@@ -407,6 +409,40 @@ impl ConstType<String> for String {
     fn unwrap(vec: &AnyVec) -> String { vec.cast_str_const() }
 }
 
+
+pub trait FromBytes<T> {
+    fn from_bytes(bytes: &[u8]) -> T;
+}
+
+impl FromBytes<u8> for u8 {
+    fn from_bytes(bytes: &[u8]) -> u8 {
+        Cursor::new(bytes).read_u8().unwrap()
+    }
+}
+
+impl FromBytes<u16> for u16 {
+    fn from_bytes(bytes: &[u8]) -> u16 {
+        Cursor::new(bytes).read_u16::<NativeEndian>().unwrap()
+    }
+}
+
+impl FromBytes<u32> for u32 {
+    fn from_bytes(bytes: &[u8]) -> u32 {
+        Cursor::new(bytes).read_u32::<NativeEndian>().unwrap()
+    }
+}
+
+impl FromBytes<u64> for u64 {
+    fn from_bytes(bytes: &[u8]) -> u64 {
+        Cursor::new(bytes).read_u64::<NativeEndian>().unwrap()
+    }
+}
+
+impl FromBytes<i64> for i64 {
+    fn from_bytes(bytes: &[u8]) -> i64 {
+        Cursor::new(bytes).read_i64::<NativeEndian>().unwrap()
+    }
+}
 
 pub trait CastUsize {
     fn cast_usize(&self) -> usize;

--- a/src/engine/vector_op/slice_pack.rs
+++ b/src/engine/vector_op/slice_pack.rs
@@ -1,6 +1,47 @@
+use std::slice;
+use std::mem;
+
 use engine::*;
 use engine::vector_op::vector_operator::*;
 
+
+#[derive(Debug)]
+pub struct SlicePackInt<T> {
+    pub input: BufferRef<T>,
+    pub output: BufferRef<Any>,
+    pub stride: usize,
+    pub offset: usize,
+}
+
+impl<'a, T: GenericIntVec<T>> VecOperator<'a> for SlicePackInt<T> {
+    fn execute(&mut self, _: bool, scratchpad: &mut Scratchpad<'a>) {
+        let data = scratchpad.get_pinned(self.input);
+        let mut packed_any = scratchpad.get_any_mut(self.output);
+        let packed = packed_any.cast_ref_mut_byte_slices();
+        for (i, datum) in data.iter().enumerate() {
+            packed.data[i * self.stride + self.offset] = bytes(datum);
+        }
+    }
+
+    fn init(&mut self, _: usize, batch_size: usize, scratchpad: &mut Scratchpad<'a>) {
+        if scratchpad.get_any(self.output).len() == 0 {
+            scratchpad.set_any(self.output, Box::new(ByteSlices {
+                row_len: self.stride,
+                data: vec![&[]; batch_size * self.stride],
+            }));
+        }
+    }
+
+    fn inputs(&self) -> Vec<BufferRef<Any>> { vec![self.input.any()] }
+    fn outputs(&self) -> Vec<BufferRef<Any>> { vec![self.output] }
+    fn can_stream_input(&self, _: usize) -> bool { false }
+    fn can_stream_output(&self, _: usize) -> bool { false }
+    fn allocates(&self) -> bool { true }
+
+    fn display_op(&self, _: bool) -> String {
+        format!("{}[{}, {}, ...] = {}", self.output, self.offset, self.offset + self.stride, self.input)
+    }
+}
 
 #[derive(Debug)]
 pub struct SlicePackString<'a> {
@@ -37,5 +78,13 @@ impl<'a> VecOperator<'a> for SlicePackString<'a> {
 
     fn display_op(&self, _: bool) -> String {
         format!("{}[{}, {}, ...] = {}", self.output, self.offset, self.offset + self.stride, self.input)
+    }
+}
+
+fn bytes<T>(t: &T) -> &[u8] {
+    let p: *const T = t;
+    let p: *const u8 = p as *const u8;
+    unsafe {
+        slice::from_raw_parts(p, mem::size_of::<T>())
     }
 }

--- a/src/engine/vector_op/slice_unpack.rs
+++ b/src/engine/vector_op/slice_unpack.rs
@@ -1,7 +1,42 @@
 use std::str;
 
+use engine::*;
 use engine::vector_op::vector_operator::*;
 
+
+#[derive(Debug)]
+pub struct SliceUnpackInt<T> {
+    pub input: BufferRef<Any>,
+    pub output: BufferRef<T>,
+    pub stride: usize,
+    pub offset: usize,
+}
+
+impl<'a, T: GenericIntVec<T>> VecOperator<'a> for SliceUnpackInt<T> {
+    fn execute(&mut self, _: bool, scratchpad: &mut Scratchpad<'a>) {
+        let packed_any = scratchpad.get_any(self.input);
+        let packed = packed_any.cast_ref_byte_slices();
+        let mut unpacked = scratchpad.get_mut(self.output);
+        for datum in packed.data.iter().skip(self.offset).step_by(self.stride) {
+            unpacked.push(T::from_bytes(datum));
+        }
+    }
+
+    fn init(&mut self, _: usize, batch_size: usize, scratchpad: &mut Scratchpad<'a>) {
+        scratchpad.set(self.output, Vec::with_capacity(batch_size));
+    }
+
+    fn inputs(&self) -> Vec<BufferRef<Any>> { vec![self.input] }
+    fn outputs(&self) -> Vec<BufferRef<Any>> { vec![self.output.any()] }
+    fn can_stream_input(&self, _: usize) -> bool { true }
+    fn can_stream_output(&self, _: usize) -> bool { true }
+    fn allocates(&self) -> bool { true }
+
+    fn display_op(&self, _: bool) -> String {
+        format!("{}[{}, {}, ...] = {}", self.output, self.offset, self.offset + self.stride, self.input)
+    }
+    fn display_output(&self) -> bool { false }
+}
 
 #[derive(Debug)]
 pub struct SliceUnpackString<'a> {

--- a/src/ingest/colgen.rs
+++ b/src/ingest/colgen.rs
@@ -30,6 +30,10 @@ pub fn int_markov_chain(
     })
 }
 
+pub fn int_uniform(low: i64, high: i64) -> Box<ColumnGenerator> {
+    Box::new(UniformInteger { low, high })
+}
+
 pub fn string_markov_chain(
     elements: Vec<String>,
     transition_probabilities: Vec<Vec<f64>>) -> Box<ColumnGenerator> {
@@ -85,6 +89,22 @@ impl<T: Sync + Send, S: ColumnBuilder<T>> ColumnGenerator for MarkovChain<T, S> 
             builder.push(&self.elem[state]);
         }
         builder.finalize(name)
+    }
+}
+
+struct UniformInteger {
+    low: i64,
+    high: i64,
+}
+
+impl ColumnGenerator for UniformInteger {
+    fn generate(&self, length: usize, name: &str, seed: u64) -> Arc<Column> {
+        let mut rng = seeded_rng(seed);
+        let mut builder = IntColBuilder::default();
+        for _ in 0..length {
+            builder.push(&rng.gen_range::<i64>(self.low, self.high));
+        }
+        ColumnBuilder::<i64>::finalize(builder, name)
     }
 }
 

--- a/src/ingest/raw_val.rs
+++ b/src/ingest/raw_val.rs
@@ -29,3 +29,9 @@ impl fmt::Display for RawVal {
     }
 }
 
+pub mod syntax {
+    pub use super::RawVal::{Int, Null};
+
+    #[allow(non_snake_case)]
+    pub fn Str(s: &str) -> super::RawVal { super::RawVal::Str(s.to_string()) }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub use ingest::csv_loader::Options as LoadOptions;
 pub use ingest::extractor;
 pub use ingest::nyc_taxi_data;
 pub use ingest::raw_val::RawVal as Value;
+pub use ingest::raw_val::syntax as value_syntax;
 pub use ingest::colgen;
 pub use locustdb::LocustDB as LocustDB;
 pub use locustdb::Options as Options;

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -373,7 +373,7 @@ fn test_column_with_null_partitions() {
 
 #[test]
 fn test_group_by_string() {
-    use Value::*;
+    use value_syntax::*;
     let _ = env_logger::try_init();
     let locustdb = LocustDB::memory_only();
     let _ = block_on(locustdb.gen_table(
@@ -385,35 +385,54 @@ fn test_group_by_string() {
                 ("hex".to_string(),
                  locustdb::colgen::random_hex_string(8)),
                 ("scrambled".to_string(),
-                 locustdb::colgen::random_string(2, 4)),
+                 locustdb::colgen::random_string(1, 2)),
+                ("ints".to_string(),
+                 locustdb::colgen::int_uniform(-10, 256))
             ],
         }
     ));
 
-    let query = "SELECT scrambled, count(1) FROM test LIMIT 3;";
+    let query = "SELECT scrambled, count(1) FROM test LIMIT 5;";
     let result = block_on(locustdb.run_query(query, true, vec![])).unwrap().0.unwrap();
     let expected_rows = vec![
-        [Str("00".to_string()), Int(2)],
-        [Str("008V".to_string()), Int(1)],
-        [Str("00dz".to_string()), Int(1)],
+        [Str("0"), Int(98)],
+        [Str("01"), Int(5)],
+        [Str("02"), Int(2)],
+        [Str("03"), Int(4)],
+        [Str("04"), Int(2)],
     ];
     assert_eq!(result.rows, expected_rows);
 
-    let query = "SELECT scrambled, scrambled, count(1) FROM test LIMIT 3;";
+    let query = "SELECT scrambled, scrambled, count(1) FROM test LIMIT 5;";
     let result = block_on(locustdb.run_query(query, true, vec![])).unwrap().0.unwrap();
     let expected_rows = vec![
-        [Str("00".to_string()), Str("00".to_string()), Int(2)],
-        [Str("008V".to_string()), Str("008V".to_string()), Int(1)],
-        [Str("00dz".to_string()), Str("00dz".to_string()), Int(1)],
+        [Str("0"), Str("0"), Int(98)],
+        [Str("01"), Str("01"), Int(5)],
+        [Str("02"), Str("02"), Int(2)],
+        [Str("03"), Str("03"), Int(4)],
+        [Str("04"), Str("04"), Int(2)],
     ];
     assert_eq!(result.rows, expected_rows);
 
-    let query = "SELECT scrambled, hex, count(1) FROM test LIMIT 3;";
+    let query = "SELECT hex, scrambled, count(1) FROM test LIMIT 5;";
     let result = block_on(locustdb.run_query(query, true, vec![])).unwrap().0.unwrap();
     let expected_rows = vec![
-        [Str("00".to_string()), Str("b0c836e5fbef7d51".to_string()), Int(1)],
-        [Str("00".to_string()), Str("ffcabba4d5975ef9".to_string()), Int(1)],
-        [Str("008V".to_string()), Str("36027c032adaf264".to_string()), Int(1)],
+        [Str("00075c14106c259a"), Str("gA"), Int(1)],
+        [Str("00096542e285cb32"), Str("g"), Int(1)],
+        [Str("001228dae6b3e755"), Str("m"), Int(1)],
+        [Str("0013492a884ee3ab"), Str("P"), Int(1)],
+        [Str("0016b50c9677802d"), Str("Y"), Int(1)]
+    ];
+    assert_eq!(result.rows, expected_rows);
+
+    let query = "SELECT ints, scrambled, count(1) FROM test LIMIT 5;";
+    let result = block_on(locustdb.run_query(query, true, vec![])).unwrap().0.unwrap();
+    let expected_rows = vec![
+        [Int(-10), Str("3I"), Int(1)],
+        [Int(-10), Str("8p"), Int(1)],
+        [Int(-10), Str("9D"), Int(1)],
+        [Int(-10), Str("9m"), Int(1)],
+        [Int(-10), Str("C"), Int(1)]
     ];
     assert_eq!(result.rows, expected_rows);
 }


### PR DESCRIPTION
Adds support for integers in generalized group bys by adding conversion
functions from/to byte slices. Also introduces a safe-ish abstraction
for pinning and taking references to temporary buffers.