### PR TITLE
Add query rewriting pass

### DIFF
--- a/src/engine/data_types/types.rs
+++ b/src/engine/data_types/types.rs
@@ -49,6 +49,12 @@ impl EncodingType {
             EncodingType::U16 => EncodingType::NullableU16,
             EncodingType::U32 => EncodingType::NullableU32,
             EncodingType::U64 => EncodingType::NullableU64,
+            EncodingType::NullableStr => EncodingType::NullableStr,
+            EncodingType::NullableI64 => EncodingType::NullableI64,
+            EncodingType::NullableU8 => EncodingType::NullableU8,
+            EncodingType::NullableU16 => EncodingType::NullableU16,
+            EncodingType::NullableU32 => EncodingType::NullableU32,
+            EncodingType::NullableU64 => EncodingType::NullableU64,
             _ => panic!("{:?} does not have a corresponding nullable type", &self)
         }
     }

--- a/src/engine/execution/buffer.rs
+++ b/src/engine/execution/buffer.rs
@@ -114,6 +114,18 @@ impl From<BufferRef<usize>> for TypedBufferRef {
     }
 }
 
+impl From<BufferRef<MergeOp>> for TypedBufferRef {
+    fn from(buffer: BufferRef<MergeOp>) -> TypedBufferRef {
+        TypedBufferRef::new(buffer.any(), EncodingType::MergeOp)
+    }
+}
+
+impl From<BufferRef<Premerge>> for TypedBufferRef {
+    fn from(buffer: BufferRef<Premerge>) -> TypedBufferRef {
+        TypedBufferRef::new(buffer.any(), EncodingType::Premerge)
+    }
+}
+
 impl<T> BufferRef<Nullable<T>> {
     pub fn cast_non_nullable(self) -> BufferRef<T> { unsafe { mem::transmute(self) } }
     pub fn nullable_any(self) -> BufferRef<Nullable<Any>> { unsafe { mem::transmute(self) } }
@@ -155,6 +167,8 @@ impl TypedBufferRef {
     pub fn forget_nullability(&self) -> TypedBufferRef {
         TypedBufferRef { buffer: self.buffer, tag: self.tag.non_nullable() }
     }
+
+    pub fn is_nullable(&self) -> bool { self.tag.is_nullable() }
 
     pub fn nullable_any<'a>(&self) -> Result<BufferRef<Nullable<Any>>, QueryError> {
         ensure!(self.tag.is_nullable(), "{:?} is not nullable", self.tag);

--- a/src/engine/operators/aggregator.rs
+++ b/src/engine/operators/aggregator.rs
@@ -1,7 +1,7 @@
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Aggregator {
-    Sum,
-    Count,
+    Sum = 0,
+    Count = 1,
 }
 
 impl Aggregator {

--- a/src/engine/operators/vector_operator.rs
+++ b/src/engine/operators/vector_operator.rs
@@ -594,8 +594,8 @@ impl<'a> VecOperator<'a> {
 
     pub fn merge_deduplicate(left: TypedBufferRef,
                              right: TypedBufferRef,
-                             merged_out: TypedBufferRef,
-                             ops_out: BufferRef<MergeOp>) -> Result<BoxedOperator<'a>, QueryError> {
+                             ops_out: BufferRef<MergeOp>,
+                             merged_out: TypedBufferRef) -> Result<BoxedOperator<'a>, QueryError> {
         reify_types! {
             "merge_deduplicate";
             left, right, merged_out: Primitive;
@@ -605,8 +605,8 @@ impl<'a> VecOperator<'a> {
 
     pub fn partition(left: TypedBufferRef,
                      right: TypedBufferRef,
-                     partition_out: BufferRef<Premerge>,
-                     limit: usize, desc: bool) -> Result<BoxedOperator<'a>, QueryError> {
+                     limit: usize, desc: bool,
+                     partition_out: BufferRef<Premerge>) -> Result<BoxedOperator<'a>, QueryError> {
         if desc {
             reify_types! {
                 "partition";
@@ -626,8 +626,8 @@ impl<'a> VecOperator<'a> {
     pub fn subpartition(partitioning: BufferRef<Premerge>,
                         left: TypedBufferRef,
                         right: TypedBufferRef,
-                        subpartition_out: BufferRef<Premerge>,
-                        desc: bool) -> Result<BoxedOperator<'a>, QueryError> {
+                        desc: bool,
+                        subpartition_out: BufferRef<Premerge>) -> Result<BoxedOperator<'a>, QueryError> {
         if desc {
             reify_types! {
                 "subpartition";
@@ -646,8 +646,8 @@ impl<'a> VecOperator<'a> {
     pub fn merge_deduplicate_partitioned(partitioning: BufferRef<Premerge>,
                                          left: TypedBufferRef,
                                          right: TypedBufferRef,
-                                         merged_out: TypedBufferRef,
-                                         ops_out: BufferRef<MergeOp>) -> Result<BoxedOperator<'a>, QueryError> {
+                                         ops_out: BufferRef<MergeOp>,
+                                         merged_out: TypedBufferRef) -> Result<BoxedOperator<'a>, QueryError> {
         reify_types! {
             "merge_deduplicate_partitioned";
             left, right, merged_out: Primitive;
@@ -669,17 +669,17 @@ impl<'a> VecOperator<'a> {
     pub fn merge_aggregate(merge_ops: BufferRef<MergeOp>,
                            left: BufferRef<i64>,
                            right: BufferRef<i64>,
-                           aggregated_out: BufferRef<i64>,
-                           aggregator: Aggregator) -> BoxedOperator<'a> {
+                           aggregator: Aggregator,
+                           aggregated_out: BufferRef<i64>) -> BoxedOperator<'a> {
         Box::new(MergeAggregate { merge_ops, left, right, aggregated: aggregated_out, aggregator })
     }
 
     pub fn merge_partitioned(partitioning: BufferRef<Premerge>,
                              left: TypedBufferRef,
                              right: TypedBufferRef,
-                             merged_out: TypedBufferRef,
+                             limit: usize, desc: bool,
                              ops_out: BufferRef<u8>,
-                             limit: usize, desc: bool) -> Result<BoxedOperator<'a>, QueryError> {
+                             merged_out: TypedBufferRef) -> Result<BoxedOperator<'a>, QueryError> {
         if desc {
             reify_types! {
                 "merge_partitioned_desc";
@@ -697,10 +697,10 @@ impl<'a> VecOperator<'a> {
 
     pub fn merge(left: TypedBufferRef,
                  right: TypedBufferRef,
-                 merged_out: TypedBufferRef,
-                 ops_out: BufferRef<u8>,
                  limit: usize,
-                 desc: bool) -> Result<BoxedOperator<'a>, QueryError> {
+                 desc: bool,
+                 ops_out: BufferRef<u8>,
+                 merged_out: TypedBufferRef) -> Result<BoxedOperator<'a>, QueryError> {
         if desc {
             reify_types! {
                 "merge_desc";

--- a/src/engine/planning/planner.rs
+++ b/src/engine/planning/planner.rs
@@ -5,6 +5,7 @@ use std::result::Result;
 use engine::*;
 use self::query_plan::prepare;
 use ::QueryError;
+use self::QueryPlan::*;
 
 
 #[derive(Default)]
@@ -14,17 +15,17 @@ pub struct QueryPlanner {
     pub cache: HashMap<[u8; 16], Vec<TypedBufferRef>>,
     checkpoint: usize,
     cache_checkpoint: HashMap<[u8; 16], Vec<TypedBufferRef>>,
-
-    buffer_count: usize,
-    shared_buffers: HashMap<&'static str, TypedBufferRef>,
+    pub buffer_provider: BufferProvider,
 }
 
 impl QueryPlanner {
-    pub fn prepare<'a>(&self) -> Result<QueryExecutor<'a>, QueryError> {
+    pub fn prepare<'a>(&mut self, mut constant_vecs: Vec<BoxedData<'a>>) -> Result<QueryExecutor<'a>, QueryError> {
+        self.perform_rewrites();
+
         let mut result = QueryExecutor::default();
-        result.set_buffer_count(self.buffer_count);
+        result.set_buffer_count(self.buffer_provider.buffer_count());
         for operation in &self.operations {
-            prepare(operation.clone(), &mut result)?;
+            prepare(operation.clone(), &mut constant_vecs, &mut result)?;
         }
         Ok(result)
     }
@@ -47,6 +48,83 @@ impl QueryPlanner {
 
     pub fn enable_common_subexpression_elimination(&self) -> bool { true }
 
+
+    fn perform_rewrites(&mut self) {
+        for i in 0..self.operations.len() {
+            match propagate_nullability(&self.operations[i], &mut self.buffer_provider) {
+                Rewrite::ReplaceWith(ops) => {
+                    trace!("Replacing {:#?} with {:#?}", self.operations[i], ops);
+                    self.operations[i] = ops[0].clone();
+                    for op in ops.into_iter().skip(1) {
+                        self.operations.push(op);
+                    }
+                }
+                Rewrite::None => {}
+            }
+        }
+    }
+}
+
+enum Rewrite {
+    None,
+    ReplaceWith(Vec<QueryPlan>),
+}
+
+fn propagate_nullability(operation: &QueryPlan, bp: &mut BufferProvider) -> Rewrite {
+    match *operation {
+        Cast { input, casted } if input.is_nullable() => {
+            let casted_non_nullable = bp.named_buffer("casted_non_nullable", casted.tag.non_nullable());
+            let cast = Cast {
+                input: input.forget_nullability(),
+                casted: casted_non_nullable,
+            };
+            let nullable = PropagateNullability {
+                nullable: input,
+                data: casted_non_nullable,
+                nullable_data: casted,
+            };
+            Rewrite::ReplaceWith(vec![cast, nullable])
+        }
+        Add { lhs, rhs, sum } if sum.is_nullable() => {
+            let sum_non_null = bp.named_buffer("sum_non_null", sum.tag.non_nullable());
+            let add = Add {
+                lhs: lhs.forget_nullability(),
+                rhs: rhs.forget_nullability(),
+                sum: sum_non_null,
+            };
+            let nullable = PropagateNullability {
+                nullable: if lhs.is_nullable() { lhs } else { rhs },
+                data: sum_non_null.into(),
+                nullable_data: sum,
+            };
+            Rewrite::ReplaceWith(vec![add, nullable])
+        }
+        MergeKeep { take_left, lhs, rhs, merged } if lhs.is_nullable() != rhs.is_nullable() => {
+            let mut ops = Vec::with_capacity(2);
+            let lhs = if lhs.is_nullable() { lhs } else {
+                let lhs_nullable = bp.named_buffer("lhs_nullable", lhs.tag.nullable());
+                ops.push(MakeNullable { data: lhs, present: bp.buffer_u8("present"), nullable: lhs_nullable });
+                lhs_nullable
+            };
+            let rhs = if rhs.is_nullable() { rhs } else {
+                let rhs_nullable = bp.named_buffer("rhs_nullable", rhs.tag.nullable());
+                ops.push(MakeNullable { data: rhs, present: bp.buffer_u8("present"), nullable: rhs_nullable });
+                rhs_nullable
+            };
+            ops.push(MergeKeep { take_left, lhs, rhs, merged });
+            Rewrite::ReplaceWith(ops)
+        }
+        _ => Rewrite::None,
+    }
+}
+
+#[derive(Default)]
+pub struct BufferProvider {
+    buffer_count: usize,
+    shared_buffers: HashMap<&'static str, TypedBufferRef>,
+}
+
+impl BufferProvider {
     pub fn named_buffer(&mut self, name: &'static str, tag: EncodingType) -> TypedBufferRef {
         let buffer = TypedBufferRef::new(BufferRef { i: self.buffer_count, name, t: PhantomData }, tag);
         self.buffer_count += 1;
@@ -85,6 +163,14 @@ impl QueryPlanner {
         self.named_buffer(name, EncodingType::ScalarString).scalar_string().unwrap()
     }
 
+    pub fn buffer_merge_op(&mut self, name: &'static str) -> BufferRef<MergeOp> {
+        self.named_buffer(name, EncodingType::MergeOp).merge_op().unwrap()
+    }
+
+    pub fn buffer_premerge(&mut self, name: &'static str) -> BufferRef<Premerge> {
+        self.named_buffer(name, EncodingType::Premerge).premerge().unwrap()
+    }
+
     pub fn shared_buffer(&mut self, name: &'static str, tag: EncodingType) -> TypedBufferRef {
         if self.shared_buffers.get(name).is_none() {
             let buffer = self.named_buffer(name, tag);
@@ -92,5 +178,6 @@ impl QueryPlanner {
         }
         self.shared_buffers[name]
     }
-}
 
+    pub fn buffer_count(&self) -> usize { self.buffer_count }
+}

--- a/src/engine/planning/query.rs
+++ b/src/engine/planning/query.rs
@@ -101,7 +101,7 @@ impl NormalFormQuery {
         for c in columns {
             debug!("{}: {:?}", partition, c);
         }
-        let mut executor = planner.prepare()?;
+        let mut executor = planner.prepare(vec![])?;
         let mut results = executor.prepare(NormalFormQuery::column_data(columns));
         debug!("{:#}", &executor);
         executor.run(columns.iter().next().unwrap().1.len(), &mut results, show);
@@ -282,7 +282,7 @@ impl NormalFormQuery {
         for c in columns {
             debug!("{}: {:?}", partition, c);
         }
-        let mut executor = planner.prepare()?;
+        let mut executor = planner.prepare(vec![])?;
         let mut results = executor.prepare(NormalFormQuery::column_data(columns));
         debug!("{:#}", &executor);
         executor.run(columns.iter().next().map(|c| c.1.len()).unwrap_or(1), &mut results, show);

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -78,8 +78,7 @@ fn test_select_string() {
     )
 }
 
-// #[test]
-// TODO(clemens): reenable once type conversion fixed
+#[test]
 fn test_select_nullable_integer() {
     test_query_ec(
         "SELECT nullable_int FROM default ORDER BY id DESC;",


### PR DESCRIPTION
Add query rewriting pass and use it to implement null propagation rules.
Add more consistent way of declaring types of outputs for query plan
variants that are generated by macro. Add QueryPlan variants for all
merge specific operators and and use query planner for constructing
batch merging plans.