### PR TITLE
Ensure no nested aggregations.

### DIFF
--- a/src/engine/planning/query.rs
+++ b/src/engine/planning/query.rs
@@ -452,7 +452,6 @@ impl Query {
             Expr::Aggregate(aggregator, expr) => {
                 let column_name = format!("_ca{}", column_names.len());
                 column_names.push(column_name.clone());
-                // TODO(clemens): ensure no nested aggregates
                 Query::ensure_no_aggregates(expr)?;
                 (Expr::ColName(column_name), vec![(*aggregator, *expr.clone())])
             }

--- a/src/locustdb.rs
+++ b/src/locustdb.rs
@@ -79,8 +79,7 @@ impl LocustDB {
                     Box::new(receiver.join(trace_receiver))
                 }
                 Err(err) => {
-                    println!("{}", err);
-                    Box::new(future::err::<_, _>(oneshot::Canceled))
+                    Box::new(future::ok((Err(err), TraceBuilder::new("empty".to_owned()).finalize())))
                 }
             }
     }


### PR DESCRIPTION
When querying nested aggregations, it will alert with detailed error message.
Before:

    locustdb> select store_and_fwd_flag, sum(sum(mta_tax)) from trips;
    Not implemented: Aggregate(Sum, ColName("mta_tax")).compile_vec()
After:

    locustdb> select store_and_fwd_flag, sum(sum(mta_tax)) from trips;
    Type error: Nested aggregates found.
    Error: Query execution was canceled!