### PR TITLE
Make LIKE operator exactly match the entire expression.

### DIFF
--- a/src/engine/planning/query_plan.rs
+++ b/src/engine/planning/query_plan.rs
@@ -789,6 +789,7 @@ impl QueryPlan {
                         pattern = Regex::new(r"^%([^%])").unwrap().replace_all(&pattern, ".*$1").to_owned().to_string();
                         pattern = Regex::new(r"([^%])%$").unwrap().replace_all(&pattern, "$1.*").to_owned().to_string();
                         pattern = Regex::new(r"%%").unwrap().replace_all(&pattern, "%").to_owned().to_string();
+                        pattern = format!("^{}$", pattern);
                         let (mut plan, t) = QueryPlan::compile_expr(expr, filter, columns, column_len, planner)?;
                         if t.decoded != BasicType::String {
                             bail!(QueryError::TypeError,

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -331,6 +331,15 @@ fn test_like() {
 }
 
 #[test]
+fn test_like_mismatch() {
+    test_query(
+        // shouldn't match Joshua etc.
+        "SELECT first_name FROM default WHERE first_name LIKE '%hu';",
+        &[],
+    );
+}
+
+#[test]
 fn test_not_equals() {
     use Value::*;
     test_query(


### PR DESCRIPTION
In `Oracle` or `MySQL`, the `LIKE` expression will match the entire expression rather than just find a substring. 
Currently, pattern like ```'%t'``` will be transformed into ```'.+t'``` which will match any string containing t.
I prepend and append 2 anchors to match the entire string.

https://docs.oracle.com/cd/B13789_01/server.101/b10759/conditions016.htm