### PR TITLE
update sqlparser-rs to 0.2.1.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
  "rustyline 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sqlparser 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sqlparser 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "std-semaphore 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.1.9"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1213,7 +1213,7 @@ dependencies = [
 "checksum seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e048636bed25842fcdc36e5ad1ec6295b72d4b5b8a4b759b64915a4ce2b9d09d"
 "checksum serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)" = "0c3adf19c07af6d186d91dae8927b83b0553d07ca56cbf7f2f32560455c91920"
 "checksum skeptic 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd7d8dc1315094150052d0ab767840376335a98ac66ef313ff911cdf439a5b69"
-"checksum sqlparser 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "235b0709ea38b7182f588afc23f28f00508de30b137e97516a006b4b54b574c9"
+"checksum sqlparser 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bd2ace0c329b16a1c87d2603de026d9c4aeaa9bb9428333251a843f7356a139e"
 "checksum std-semaphore 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33ae9eec00137a8eed469fb4148acd9fc6ac8c3f9b110f52cd34698c8b5bfa0e"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ seahash = "3.0.5"
 std-semaphore = "0.1.0"
 tempdir = "0.3.7"
 time = "0.1.36"
-sqlparser = "0.1.9"
+sqlparser = "0.2.1"
 
 [dependencies.capnp]
 optional = true

--- a/src/syntax/expression.rs
+++ b/src/syntax/expression.rs
@@ -29,6 +29,7 @@ pub enum Func2Type {
     Modulo,
     RegexMatch,
     Like,
+    NotLike,
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -323,10 +323,26 @@ fn test_regex() {
 }
 
 #[test]
+fn test_not_regex() {
+    test_query(
+        "SELECT first_name FROM default WHERE not(regex(first_name, '^C.+h.a')) LIMIT 1;",
+        &[vec![Str("Victor")]],
+    );
+}
+
+#[test]
 fn test_like() {
     test_query(
         "SELECT first_name FROM default WHERE first_name LIKE 'C%h_a';",
         &[vec![Str("Cynthia")]],
+    );
+}
+
+#[test]
+fn test_not_like() {
+    test_query(
+        "SELECT first_name FROM default WHERE first_name NOT LIKE 'C%h_a' LIMIT 1;",
+        &[vec![Str("Kathryn")]],
     );
 }
 
@@ -344,6 +360,22 @@ fn test_not_equals() {
     use Value::*;
     test_query(
         "select num, count(1) from default where num <> 0;",
+        &[
+            vec![Int(1), Int(49)],
+            vec![Int(2), Int(24)],
+            vec![Int(3), Int(11)],
+            vec![Int(4), Int(5)],
+            vec![Int(5), Int(2)],
+            vec![Int(8), Int(1)]
+        ],
+    )
+}
+
+#[test]
+fn test_not_equals_2() {
+    use Value::*;
+    test_query(
+        "select num, count(1) from default where not(num = 0);",
         &[
             vec![Int(1), Int(49)],
             vec![Int(2), Int(24)],
@@ -383,9 +415,7 @@ fn test_groupless_aggregate() {
         &[vec![Int(16197630), Int(10000)]],
     );
     test_query_nyc(
-        "SELECT count(0) FROM default WHERE passenger_count = 1;",
-        // TODO(sqlparser-rs#30): Use this once parser bug is fixed
-        // "SELECT count(0) FROM default WHERE NOT passenger_count <> 1;",
+         "SELECT count(0) FROM default WHERE NOT passenger_count <> 1;",
         &[vec![Int(6016)]],
     );
 }


### PR DESCRIPTION
update sqlparser-rs to 0.2.1 w/ following updates.
1. unary function `NOT`;
2. `NOT LIKE`

Unit tests have also been added.

BTW: I am wandering if we can migrate to nickolay's fork of [sqlparser-rs](https://github.com/nickolay/sqlparser-rs) which supports `alias`, `in`, etc.