### PR TITLE
Fix packed string encoding

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,23 +14,23 @@ jobs:
           - os: macos-latest
 
     steps:
-    - uses: actions/checkout@v2    
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         components: rustfmt, clippy
 
     - name: Cache cargo registry
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cargo/registry
         key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
     - name: Cache cargo index
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cargo/git
         key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
     - name: Cache cargo build
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: target
         key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -1690,9 +1690,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mime"
@@ -1807,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "6.2.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
 dependencies = [
  "bitvec",
  "funty",
@@ -2386,14 +2386,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
@@ -2407,9 +2406,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "remove_dir_all"
@@ -2895,7 +2894,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "libc",
- "nom 6.2.1",
+ "nom 6.1.2",
  "time 0.1.44",
  "winapi 0.3.9",
 ]

--- a/src/stringpack.rs
+++ b/src/stringpack.rs
@@ -57,7 +57,7 @@ impl PackedStrings {
         let mut len = b.len();
         while len > 254 {
             self.data.push(255);
-            len -= 254;
+            len -= 255;
         }
         self.data.push(len as u8);
         self.data.extend_from_slice(b);

--- a/src/stringpack.rs
+++ b/src/stringpack.rs
@@ -10,7 +10,8 @@ impl IndexedPackedStrings {
     pub fn push(&mut self, elem: &str) {
         let bytes = elem.as_bytes();
         // TODO(34): overflow
-        self.data.push(((self.backing_store.len() << 24) + bytes.len()) as u64);
+        self.data
+            .push(((self.backing_store.len() << 24) + bytes.len()) as u64);
         self.backing_store.extend_from_slice(bytes);
     }
 
@@ -19,7 +20,7 @@ impl IndexedPackedStrings {
         self.backing_store.clear();
     }
 
-    pub fn iter(&self) -> impl Iterator<Item=&str> + Clone {
+    pub fn iter(&self) -> impl Iterator<Item = &str> + Clone {
         self.data.iter().map(move |&offset_len| unsafe {
             let offset = (offset_len >> 24) as usize;
             let len = (offset_len & 0x00ff_ffff) as usize;
@@ -42,7 +43,7 @@ pub struct PackedStrings {
 
 // PERF: encode using variable size length
 impl PackedStrings {
-    pub fn from_iterator<'a>(strings: impl Iterator<Item=&'a str>) -> PackedStrings {
+    pub fn from_iterator<'a>(strings: impl Iterator<Item = &'a str>) -> PackedStrings {
         let mut sp = PackedStrings { data: Vec::new() };
         for string in strings {
             sp.push(string);
@@ -52,10 +53,14 @@ impl PackedStrings {
     }
 
     pub fn push(&mut self, string: &str) {
-        for &byte in string.as_bytes().iter() {
-            self.data.push(byte);
+        let b = string.as_bytes();
+        let mut len = b.len();
+        while len > 254 {
+            self.data.push(255);
+            len -= 254;
         }
-        self.data.push(0);
+        self.data.push(len as u8);
+        self.data.extend_from_slice(b);
     }
 
     pub fn shrink_to_fit(&mut self) {
@@ -75,7 +80,10 @@ pub struct StringPackerIterator<'a> {
 impl<'a> StringPackerIterator<'a> {
     /// `data` must be valid encoding for StringPacker
     pub unsafe fn from_slice(data: &'a [u8]) -> StringPackerIterator<'a> {
-        StringPackerIterator { data, curr_index: 0 }
+        StringPackerIterator {
+            data,
+            curr_index: 0,
+        }
     }
 }
 
@@ -87,12 +95,17 @@ impl<'a> Iterator for StringPackerIterator<'a> {
             return None;
         }
 
-        let mut index = self.curr_index;
-        while self.data[index] != 0 {
-            index += 1;
+        let mut len = 0usize;
+        while self.data[self.curr_index] == 255 {
+            len += 255;
+            self.curr_index += 1;
         }
-        let result = unsafe { str::from_utf8_unchecked(&self.data[self.curr_index..index]) };
-        self.curr_index = index + 1;
+        len += self.data[self.curr_index] as usize;
+        self.curr_index += 1;
+
+        let result =
+            unsafe { str::from_utf8_unchecked(&self.data[self.curr_index..self.curr_index + len]) };
+        self.curr_index += len;
         Some(result)
     }
 }
@@ -103,7 +116,7 @@ pub struct PackedBytes {
 }
 
 impl PackedBytes {
-    pub fn from_iterator(bytes: impl Iterator<Item=Vec<u8>>) -> PackedBytes {
+    pub fn from_iterator(bytes: impl Iterator<Item = Vec<u8>>) -> PackedBytes {
         let mut data = Vec::<u8>::new();
         for b in bytes {
             let mut len = b.len();
@@ -130,7 +143,10 @@ pub struct PackedBytesIterator<'a> {
 
 impl<'a> PackedBytesIterator<'a> {
     pub fn from_slice(data: &'a [u8]) -> PackedBytesIterator<'a> {
-        PackedBytesIterator { data, curr_index: 0 }
+        PackedBytesIterator {
+            data,
+            curr_index: 0,
+        }
     }
 
     pub fn has_more(&self) -> bool {


### PR DESCRIPTION
`PackedStrings` was encoding strings with a null-terminator, which breaks for strings that contain null bytes. Prefix each string with a length header instead.

Resolves https://github.com/cswinter/LocustDB/issues/152