### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/engine/execution/query_task.rs
+++ b/src/engine/execution/query_task.rs
@@ -231,10 +231,10 @@ impl QueryTask {
         state.explains.extend(explains);
         state.rows_scanned += rows_scanned;
         state.rows_collected += rows_collected;
-        unsafe {
-            let result = mem::transmute::<_, BatchResult<'static>>(result);
+        
+            let result = unsafe { mem::transmute::<_, BatchResult<'static>>(result) };
             state.partial_results.push(result);
-        }
+        
         if state.completed_batches == self.partitions.len()
             || self.sufficient_rows(state.rows_collected)
         {

--- a/src/stringpack.rs
+++ b/src/stringpack.rs
@@ -21,10 +21,10 @@ impl IndexedPackedStrings {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &str> + Clone {
-        self.data.iter().map(move |&offset_len| unsafe {
+        self.data.iter().map(move |&offset_len| {
             let offset = (offset_len >> 24) as usize;
             let len = (offset_len & 0x00ff_ffff) as usize;
-            str::from_utf8_unchecked(&self.backing_store[offset..(offset + len)])
+            unsafe { str::from_utf8_unchecked(&self.backing_store[offset..(offset + len)]) }
         })
     }
 


### PR DESCRIPTION
In this function you use the unsafe keyword for some safe expressions.

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
References
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html