### PR TITLE
Query engine fixes

### DIFF
--- a/locustdb-derive/src/ast_builder.rs
+++ b/locustdb-derive/src/ast_builder.rs
@@ -144,6 +144,10 @@ pub fn ast_builder(input: TokenStream) -> TokenStream {
                             self.cache.insert(signature, vec![#(#result2.into()),*]);
                         }
 
+                        if std::env::var("EARLY_OPERATOR_CHECK").is_ok() {
+                            self.clone().prepare(vec![], 1024, false).unwrap();
+                        }
+
                         (#(#result),*)
                     }
                 };

--- a/src/engine/execution/batch_merging.rs
+++ b/src/engine/execution/batch_merging.rs
@@ -50,7 +50,8 @@ impl<'a> BatchResult<'a> {
         Ok(())
     }
 
-    pub fn into_columns(self) -> HashMap<String, Arc<dyn DataSource + 'a>> {
+    #[must_use]
+    pub fn into_columns(self) -> (HashMap<String, Arc<dyn DataSource + 'a>>, Vec<BoxedData<'a>>) {
         let mut cols = HashMap::<String, Arc<dyn DataSource>>::default();
         let columns = self.columns.into_iter().map(Arc::new).collect::<Vec<_>>();
         for projection in self.projection {
@@ -59,7 +60,7 @@ impl<'a> BatchResult<'a> {
         for (i, &(aggregation, _)) in self.aggregations.iter().enumerate() {
             cols.insert(format!("_ca{}", i), columns[aggregation].clone());
         }
-        cols
+        (cols, self.unsafe_referenced_buffers)
     }
 }
 

--- a/src/engine/execution/query_task.rs
+++ b/src/engine/execution/query_task.rs
@@ -318,7 +318,7 @@ impl QueryTask {
             }
             let full_result = owned_results.into_iter().next().unwrap().1;
             let final_result = if let Some(final_pass) = &self.final_pass {
-                let data_sources = full_result.into_columns();
+                let (data_sources, _unsafe_referenced_buffers) = full_result.into_columns();
                 let cols = unsafe {
                     mem::transmute::<
                         &HashMap<String, Arc<dyn DataSource>>,

--- a/src/engine/operators/vector_operator.rs
+++ b/src/engine/operators/vector_operator.rs
@@ -622,7 +622,7 @@ pub mod operator {
         output: TypedBufferRef,
     ) -> Result<BoxedOperator<'a>, QueryError> {
         if input.is_null() {
-            Ok(null_vec_like(input.any(), output.any(), LengthSource::InputLength))
+            Ok(null_vec_like(indices.any(), output.any(), LengthSource::InputLength))
         } else {
             reify_types! {
                 "select";
@@ -696,6 +696,13 @@ pub mod operator {
             EncodingType::U8 => Ok(Box::new(ConstantExpand {
                 val: val as u8,
                 output: output.u8()?,
+                current_index: 0,
+                len,
+                batch_size: 0, // initialized later
+            })),
+            EncodingType::I64 => Ok(Box::new(ConstantExpand {
+                val,
+                output: output.i64()?,
                 current_index: 0,
                 len,
                 batch_size: 0, // initialized later

--- a/src/engine/planning/filter.rs
+++ b/src/engine/planning/filter.rs
@@ -1,4 +1,4 @@
-use crate::engine::{BufferRef, Nullable};
+use crate::engine::{BufferRef, Nullable, QueryPlanner, TypedBufferRef};
 
 #[derive(Clone, Copy, Default)]
 pub enum Filter {
@@ -7,4 +7,16 @@ pub enum Filter {
     U8(BufferRef<u8>),
     NullableU8(BufferRef<Nullable<u8>>),
     Indices(BufferRef<usize>),
+}
+
+
+impl Filter {
+    pub fn apply_filter(self, planner: &mut QueryPlanner, plan: TypedBufferRef) -> TypedBufferRef {
+        match self {
+            Filter::U8(filter) => planner.filter(plan, filter),
+            Filter::NullableU8(filter) => planner.nullable_filter(plan, filter),
+            Filter::Indices(indices) => planner.select(plan, indices),
+            Filter::None => plan,
+        }
+    }
 }

--- a/src/engine/planning/planner.rs
+++ b/src/engine/planning/planner.rs
@@ -6,7 +6,7 @@ use std::marker::PhantomData;
 use self::query_plan::prepare;
 use self::QueryPlan::*;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct QueryPlanner {
     pub operations: Vec<QueryPlan>,
     pub buffer_to_operation: Vec<Option<usize>>,
@@ -351,7 +351,7 @@ fn combine_nulls2(bp: &mut BufferProvider,
     (combined_null_map, plan)
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct BufferProvider {
     buffer_count: usize,
     pub all_buffers: Vec<TypedBufferRef>,

--- a/src/engine/planning/query_plan.rs
+++ b/src/engine/planning/query_plan.rs
@@ -932,12 +932,7 @@ impl QueryPlan {
                         t = Type::encoded(codec);
                         plan = fixed_width;
                     }
-                    plan = match filter {
-                        Filter::U8(filter) => planner.filter(plan, filter),
-                        Filter::NullableU8(filter) => planner.nullable_filter(plan, filter),
-                        Filter::Indices(indices) => planner.select(plan, indices),
-                        Filter::None => plan,
-                    };
+                    plan = filter.apply_filter(planner, plan);
                     (plan, t)
                 }
                 None => {

--- a/src/mem_store/strings.rs
+++ b/src/mem_store/strings.rs
@@ -31,7 +31,6 @@ where
     for s in strings.clone() {
         unique_values.insert(s);
         // PERF: is 2 the right constant? and should probably also depend on the length of the strings
-        // TODO(#103): len > 1000 || name == "string_packed" is a hack to make tests use dictionary encoding. Remove once we are able to group by string packed columns.
         if unique_values.len() == len / DICTIONARY_RATIO {
             let (mut codec, data) = if (lhex || uhex) && total_bytes / len > 5 {
                 let packed = PackedBytes::from_iterator(strings.map(|s| hex::decode(s).unwrap()));


### PR DESCRIPTION
Fix unsoundness issue caused by dropping referenced buffers before final query pass in multi-stage queries, add support for grouping by null columns, make query tests deterministic.